### PR TITLE
Add knowledge ingestion + retrieval and consolidate env config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,22 @@
+# Local-dev environment manifest.
+# Copy to .env and fill in the blanks (OPENAI_API_KEY).
+# In production, ECS task defs / Secrets Manager / SSM inject these same
+# names; no .env file is deployed.
+
+# Postgres credentials consumed by docker-compose (with these defaults
+# baked into docker-compose.yml as fallbacks).
 POSTGRES_USER=portfolio
 POSTGRES_PASSWORD=portfolio
 POSTGRES_DB=portfolio_ai
 POSTGRES_PORT=5432
 
-DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT}/${POSTGRES_DB}?schema=public"
+# Postgres connection string consumed by Node code (Prisma, scripts).
+# NOTE: Node's --env-file and dotenv do NOT expand ${VAR}, so this must
+# be a literal URL. If you change any POSTGRES_* above, update this line
+# to match (or just leave both at their defaults).
+DATABASE_URL=postgresql://portfolio:portfolio@localhost:5432/portfolio_ai?schema=public
+
+# OpenAI embeddings (consumed by @portfolio/db and future packages).
+OPENAI_API_KEY=
+EMBEDDING_MODEL=text-embedding-3-small
+EMBEDDING_DIMENSIONS=1536

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   },
   "packageManager": "pnpm@9.0.0",
   "engines": {
-    "node": ">=18"
+    "node": ">=20.11"
   }
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -13,6 +13,10 @@
     "./twilio": {
       "types": "./src/twilio.ts",
       "default": "./src/twilio.ts"
+    },
+    "./knowledge": {
+      "types": "./src/knowledge.ts",
+      "default": "./src/knowledge.ts"
     }
   },
   "scripts": {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./common.js";
 export * from "./channel.js";
+export * from "./knowledge.js";

--- a/packages/contracts/src/knowledge.ts
+++ b/packages/contracts/src/knowledge.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+import { MetadataSchema, NonEmptyStringSchema } from "./common.js";
+
+export const KnowledgeSourceTypeSchema = z.enum(["portfolio", "project", "experience", "skill", "dev_fixture"]);
+
+export const KnowledgeDocumentInputSchema = z.object({
+  title: NonEmptyStringSchema,
+  sourceType: KnowledgeSourceTypeSchema,
+  sourceUri: NonEmptyStringSchema.optional(),
+  content: NonEmptyStringSchema,
+  metadata: MetadataSchema.optional()
+});
+
+export const RetrievedChunkSchema = z.object({
+  documentId: NonEmptyStringSchema,
+  chunkId: NonEmptyStringSchema,
+  title: z.string().nullable(),
+  content: NonEmptyStringSchema,
+  sourceType: KnowledgeSourceTypeSchema,
+  score: z.number().min(0).max(1),
+  rank: z.number().int().min(1)
+});
+
+export const RetrievalQuerySchema = z.object({
+  query: NonEmptyStringSchema,
+  topK: z.number().int().min(1).max(50).default(5),
+  sourceType: KnowledgeSourceTypeSchema.optional(),
+  minSimilarity: z.number().min(0).max(1).optional()
+});
+
+export type KnowledgeSourceType = z.infer<typeof KnowledgeSourceTypeSchema>;
+export type KnowledgeDocumentInput = z.infer<typeof KnowledgeDocumentInputSchema>;
+export type RetrievedChunk = z.infer<typeof RetrievedChunkSchema>;
+export type RetrievalQuery = z.infer<typeof RetrievalQuerySchema>;

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,0 +1,155 @@
+# `@portfolio/db`
+
+Prisma 7 + Postgres + pgvector data layer for the portfolio AI assistant.
+Hosts the singleton `prisma` client, the schema/migrations, and the
+knowledge ingestion and retrieval primitives consumed by the future
+`packages/agent` and `apps/api`.
+
+The package is consumed as TypeScript source (`main` and `types` point at
+`src/index.ts`) — there is no compiled `dist/` and no `build` script.
+
+## Environment
+
+All env vars live in the **repo-root `.env.example`** — there is no
+package-level `.env*` file. From the repo root:
+
+```bash
+cp .env.example .env
+# then paste your real OPENAI_API_KEY into .env
+```
+
+| Variable | Required for | Default | Notes |
+| --- | --- | --- | --- |
+| `DATABASE_URL` | every DB-touching command | — | Built from the `POSTGRES_*` vars by interpolation in `.env.example`; matches the docker-compose service. |
+| `OPENAI_API_KEY` | `seed:knowledge`, `smoke:retrieval`, any embedding flow | — | Validated by `getEmbeddingEnv()` only; DB-only commands (`db:migrate`, `db:studio`, `db:generate`) do **not** require it. |
+| `EMBEDDING_MODEL` | embedding flows | `text-embedding-3-small` | Must produce vectors that match `EMBEDDING_DIMENSIONS`. |
+| `EMBEDDING_DIMENSIONS` | embedding flows | `1536` | Must match the `vector(N)` column. Changing it is a schema migration **and** a full re-embed. |
+
+### How env is loaded
+
+- **`prisma.config.ts`** loads the root `.env` via
+  `dotenv.config({ path: resolve(import.meta.dirname, "../../.env") })`.
+  Prisma CLI has no `--env-file` flag, so we resolve the path explicitly
+  and never depend on CWD.
+- **`tsx` scripts (`seed:knowledge`, `smoke:retrieval`)** use Node's
+  native `--env-file=../../.env` flag. No `dotenv` import in the script
+  entry points.
+- **Runtime code** never touches `process.env` directly. It calls the
+  split, Zod-validated accessors in `src/env.ts`:
+  - `getDatabaseEnv()` — `DATABASE_URL` only. Used by the Prisma client
+    in `src/index.ts`.
+  - `getEmbeddingEnv()` — `OPENAI_API_KEY` + embedding model/dimensions.
+    Used by the OpenAI provider.
+
+  Both accessors are lazy and cached; either throws a Zod field-level
+  error at first call if something is missing or malformed.
+
+### Production
+
+- `.env*` files are local-only and never deployed.
+- In production, ECS task definitions (or EKS Pod manifests via
+  `envFrom` / `secretKeyRef`) inject the same variable names into
+  `process.env`, sourced from AWS Secrets Manager / SSM Parameter Store.
+- `DATABASE_URL` points at RDS / Aurora PostgreSQL with the `vector`
+  extension enabled in the cluster.
+- Runtime code paths are identical across local, staging, and prod —
+  `getDatabaseEnv()` and `getEmbeddingEnv()` validate whatever
+  `process.env` carries.
+
+## Local Postgres
+
+The repo root ships a `docker-compose.yml` that runs
+`pgvector/pgvector:pg17` and bootstraps the `vector` extension. From the
+repo root:
+
+```bash
+docker compose up -d
+```
+
+## Commands
+
+Run from anywhere via the workspace filter.
+
+```bash
+# After cloning, or after schema/generator changes:
+pnpm --filter @portfolio/db db:generate
+
+# Apply migrations to the local database:
+pnpm --filter @portfolio/db db:migrate
+
+# Open Prisma Studio:
+pnpm --filter @portfolio/db db:studio
+
+# Type-check:
+pnpm --filter @portfolio/db check-types
+
+# Seed the knowledge base (idempotent — re-runs skip unchanged docs):
+pnpm --filter @portfolio/db seed:knowledge
+
+# Smoke-test retrieval:
+pnpm --filter @portfolio/db smoke:retrieval
+```
+
+## Why raw SQL for vector columns
+
+`DocumentChunk.embedding` is declared as `Unsupported("vector(1536)")?`.
+Prisma's typed client cannot bind or project that column, so vector
+inserts and similarity queries are written as parameterized raw SQL via
+`prisma.$executeRaw` / `prisma.$queryRaw`. We use the `pgvector` npm
+package's `toSql(array)` helper to format the value, then cast it to
+`vector(1536)` in SQL:
+
+```sql
+INSERT INTO "DocumentChunk" (..., "embedding", ...)
+VALUES (..., $N::vector(1536), ...)
+```
+
+Similarity search uses pgvector's cosine-distance operator `<=>`. We
+report similarity as `1 - distance` and rely on the partial HNSW index
+defined in the initial migration:
+
+```sql
+SELECT 1 - (c."embedding" <=> $1::vector(1536)) AS score
+  FROM "DocumentChunk" c
+  JOIN "Document" d ON d."id" = c."documentId"
+ WHERE d."isActive" = true
+   AND c."embedding" IS NOT NULL
+ ORDER BY c."embedding" <=> $1::vector(1536) ASC
+ LIMIT $K
+```
+
+## Layout
+
+```
+src/
+  index.ts                  -- singleton prisma client + re-exports
+  env.ts                    -- getDatabaseEnv() / getEmbeddingEnv() (Zod, lazy)
+  embeddings/
+    types.ts                -- EmbeddingProvider interface
+    openai.ts               -- OpenAI implementation (lazy client, batching, validation)
+    index.ts                -- getEmbeddingProvider() factory
+  knowledge/
+    documents.ts            -- computeContentHash, upsertDocument (idempotent)
+    chunking.ts             -- pure chunkText() with paragraph-aware splits
+    chunks.ts               -- replaceDocumentChunks() inside prisma.$transaction
+    retrieve.ts             -- retrieveChunks() with Zod-validated output
+scripts/
+  seed-knowledge-data.ts    -- real portfolio content + clearly labeled dev fixtures
+  seed-knowledge.ts         -- ingestion runner
+  smoke-retrieval.ts        -- end-to-end retrieval sanity check
+prisma/
+  schema.prisma             -- models, including DocumentChunk.embedding vector(1536)
+  migrations/               -- includes pgvector extension + HNSW cosine index
+```
+
+## Changing the embedding dimension
+
+Updating `EMBEDDING_DIMENSIONS` to anything other than 1536 requires:
+
+1. Editing the `Unsupported("vector(N)")` declaration in
+   `prisma/schema.prisma`.
+2. Writing a migration that alters the column type and re-creates the
+   HNSW index (cosine distance ops are dimension-specific).
+3. Re-running `seed:knowledge` so every stored chunk is re-embedded.
+
+Do not switch models without doing all three.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -15,12 +15,19 @@
     "check-types": "tsc --noEmit",
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
-    "db:studio": "prisma studio"
+    "db:studio": "prisma studio",
+    "seed:knowledge": "tsx --env-file=../../.env scripts/seed-knowledge.ts",
+    "smoke:retrieval": "tsx --env-file=../../.env scripts/smoke-retrieval.ts"
   },
   "dependencies": {
+    "@portfolio/content": "workspace:*",
+    "@portfolio/contracts": "workspace:*",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
-    "dotenv": "^17.4.2"
+    "dotenv": "^17.4.2",
+    "openai": "^5.0.0",
+    "pgvector": "^0.2.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@portfolio/typescript-config": "workspace:*",

--- a/packages/db/prisma.config.ts
+++ b/packages/db/prisma.config.ts
@@ -1,5 +1,11 @@
-import "dotenv/config";
+import path from "node:path";
+
+import { config } from "dotenv";
 import { defineConfig, env } from "prisma/config";
+
+// Load env from the repo-root .env explicitly. Avoids relying on CWD and
+// prevents drifting toward a package-level duplicate .env file.
+config({ path: path.resolve(import.meta.dirname, "../../.env") });
 
 export default defineConfig({
   schema: "prisma/schema.prisma",

--- a/packages/db/scripts/seed-knowledge-data.ts
+++ b/packages/db/scripts/seed-knowledge-data.ts
@@ -1,0 +1,122 @@
+// Seed content for the portfolio knowledge base.
+//
+// All real content is sourced from @portfolio/content — the single source
+// of truth shared with apps/web. devFixtureDocuments exists only to
+// exercise ingestion for topics the portfolio does not yet document
+// (e.g. AI engineering positioning); delete each fixture when real copy
+// lands.
+
+import {
+  bioParagraphs,
+  contact,
+  fullName,
+  greeting,
+  projects,
+  tagline,
+} from "@portfolio/content";
+import type { KnowledgeDocumentInput } from "@portfolio/contracts/knowledge";
+
+const REAL_METADATA = {
+  isPlaceholder: false,
+  source: "existing_portfolio"
+} as const;
+
+const FIXTURE_METADATA = {
+  isPlaceholder: true,
+  source: "dev_fixture"
+} as const;
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+const projectDocuments: KnowledgeDocumentInput[] = projects.map((project) => {
+  const slug = `${slugify(project.company)}-${slugify(project.year)}-${slugify(project.title)}`;
+  return {
+    title: `${project.title} (${project.company}, ${project.year})`,
+    sourceType: "project",
+    sourceUri: `@portfolio/content/projects#${slug}`,
+    content: [
+      project.title,
+      `Role: ${project.role}`,
+      `Company: ${project.company}`,
+      `Years: ${project.year}`,
+      "",
+      project.description
+    ].join("\n"),
+    metadata: {
+      ...REAL_METADATA,
+      role: project.role,
+      company: project.company,
+      year: project.year,
+      slug
+    }
+  };
+});
+
+// Bio paragraphs retain their markdown `**bold**` markers; embedding
+// models treat them as inert noise, so stripping isn't necessary.
+const aboutBioContent = bioParagraphs.join("\n\n");
+
+const portfolioDocuments: KnowledgeDocumentInput[] = [
+  {
+    title: "Bio — David Bautista",
+    sourceType: "portfolio",
+    sourceUri: "@portfolio/content/bio",
+    content: aboutBioContent,
+    metadata: REAL_METADATA
+  },
+  {
+    title: "Tagline — David Bautista",
+    sourceType: "portfolio",
+    sourceUri: "@portfolio/content/identity",
+    content: `${greeting} ${fullName.first} ${fullName.last}. ${tagline}.`,
+    metadata: REAL_METADATA
+  },
+  {
+    title: "Contact channels",
+    sourceType: "portfolio",
+    sourceUri: "@portfolio/content/contact",
+    content: [
+      "Let's connect — David is always open to new opportunities and collaborations.",
+      "",
+      `Email: ${contact.email}`,
+      `GitHub: ${contact.github.url} (handle: ${contact.github.handle})`,
+      `LinkedIn: ${contact.linkedin.url} (${contact.linkedin.name})`,
+      `Resume: ${contact.resumePath}`
+    ].join("\n"),
+    metadata: REAL_METADATA
+  }
+];
+
+// Stack-focused doc so retrieval can answer "what is David's stack?"
+// precisely. Mirrors the stack paragraph from @portfolio/content/bio verbatim.
+const skillsDocuments: KnowledgeDocumentInput[] = [
+  {
+    title: "Primary stack",
+    sourceType: "skill",
+    sourceUri: "@portfolio/content/bio#stack",
+    content: bioParagraphs[1] ?? "",
+    metadata: REAL_METADATA
+  }
+];
+
+export const realPortfolioDocuments: KnowledgeDocumentInput[] = [...portfolioDocuments, ...projectDocuments, ...skillsDocuments];
+
+// Placeholders. Used only because the portfolio does not yet document
+// these topics. Remove each fixture as soon as real copy exists.
+export const devFixtureDocuments: KnowledgeDocumentInput[] = [
+  {
+    title: "AI engineering positioning (placeholder)",
+    sourceType: "dev_fixture",
+    sourceUri: "packages/db/scripts/seed-knowledge-data.ts#ai-positioning",
+    content:
+      "AI engineering positioning placeholder — replace with real positioning copy before demo. This document exists only to exercise the dev_fixture ingestion path; do not treat its contents as truthful portfolio claims.",
+    metadata: FIXTURE_METADATA
+  }
+];
+
+export const allSeedDocuments: KnowledgeDocumentInput[] = [...realPortfolioDocuments, ...devFixtureDocuments];

--- a/packages/db/scripts/seed-knowledge.ts
+++ b/packages/db/scripts/seed-knowledge.ts
@@ -1,0 +1,133 @@
+import type { KnowledgeDocumentInput } from "@portfolio/contracts/knowledge";
+
+import { getEmbeddingProvider } from "../src/embeddings/index.js";
+import { chunkText } from "../src/knowledge/chunking.js";
+import { replaceDocumentChunks } from "../src/knowledge/chunks.js";
+import { upsertDocument } from "../src/knowledge/documents.js";
+import { prisma, Prisma } from "../src/index.js";
+
+import { allSeedDocuments } from "./seed-knowledge-data.js";
+
+// Identifies rows this seed owns. The cleanup pass only removes documents
+// whose metadata.source matches one of these values — production rows
+// without the flag are never touched.
+const SEED_MANAGED_SOURCES = ["existing_portfolio", "dev_fixture"] as const;
+
+type Status = "inserted" | "updated" | "skipped";
+
+interface DocReport {
+  title: string;
+  sourceType: string;
+  status: Status;
+  chunks: number;
+  ms: number;
+}
+
+async function main(): Promise<void> {
+  const provider = getEmbeddingProvider();
+  console.log(`[seed] using embedding provider model=${provider.model} dimensions=${provider.dimensions}`);
+
+  const reports: DocReport[] = [];
+
+  for (const input of allSeedDocuments) {
+    const started = Date.now();
+
+    const { document, changed, created } = await upsertDocument(input);
+
+    if (!changed) {
+      const existingChunkCount = await prisma.documentChunk.count({
+        where: { documentId: document.id }
+      });
+      if (existingChunkCount > 0) {
+        reports.push({
+          title: input.title,
+          sourceType: input.sourceType,
+          status: "skipped",
+          chunks: existingChunkCount,
+          ms: Date.now() - started
+        });
+        continue;
+      }
+    }
+
+    const chunks = chunkText(input.content).map((chunk) => ({
+      ...chunk,
+      title: input.title,
+      metadata: input.metadata ?? null
+    }));
+
+    if (chunks.length === 0) {
+      throw new Error(`[seed] document "${input.title}" produced zero chunks; refusing to embed.`);
+    }
+
+    const embeddings = await provider.embed(chunks.map((c) => c.content));
+    const result = await replaceDocumentChunks(document.id, chunks, embeddings);
+
+    reports.push({
+      title: input.title,
+      sourceType: input.sourceType,
+      status: created ? "inserted" : "updated",
+      chunks: result.inserted,
+      ms: Date.now() - started
+    });
+  }
+
+  console.log("[seed] per-document results:");
+  for (const r of reports) {
+    console.log(JSON.stringify(r));
+  }
+
+  const totals = reports.reduce(
+    (acc, r) => {
+      acc[r.status] += 1;
+      acc.chunks += r.chunks;
+      return acc;
+    },
+    { inserted: 0, updated: 0, skipped: 0, chunks: 0 }
+  );
+
+  const removed = await pruneStaleSeedDocuments(allSeedDocuments);
+  if (removed > 0) {
+    console.log(`[seed] pruned ${removed} stale seed-managed document(s).`);
+  }
+
+  console.log(
+    `[seed] totals: documents=${reports.length} inserted=${totals.inserted} updated=${totals.updated} skipped=${totals.skipped} chunks=${totals.chunks} pruned=${removed}`
+  );
+}
+
+function seedKey(sourceType: string, sourceUri: string | null, title: string): string {
+  return `${sourceType}|${sourceUri ?? ""}|${title}`;
+}
+
+async function pruneStaleSeedDocuments(current: readonly KnowledgeDocumentInput[]): Promise<number> {
+  const managed = await prisma.document.findMany({
+    where: {
+      OR: SEED_MANAGED_SOURCES.map((source) => ({
+        metadata: {
+          path: ["source"],
+          equals: source
+        } as Prisma.JsonFilter<"Document">
+      }))
+    },
+    select: { id: true, sourceType: true, sourceUri: true, title: true }
+  });
+
+  const currentKeys = new Set(current.map((d) => seedKey(d.sourceType, d.sourceUri ?? null, d.title)));
+  const stale = managed.filter((row) => !currentKeys.has(seedKey(row.sourceType, row.sourceUri, row.title)));
+
+  if (stale.length === 0) return 0;
+  const result = await prisma.document.deleteMany({
+    where: { id: { in: stale.map((s) => s.id) } }
+  });
+  return result.count;
+}
+
+main()
+  .catch((err) => {
+    console.error("[seed] failed:", err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/packages/db/scripts/smoke-retrieval.ts
+++ b/packages/db/scripts/smoke-retrieval.ts
@@ -1,0 +1,38 @@
+import { retrieveChunks } from "../src/knowledge/retrieve.js";
+import { prisma } from "../src/index.js";
+
+const QUERY = "What is David's stack?";
+const TOP_K = 5;
+
+async function main(): Promise<void> {
+  console.log(`[smoke] query: ${QUERY}`);
+  const results = await retrieveChunks({ query: QUERY, topK: TOP_K });
+
+  if (results.length === 0) {
+    console.error("[smoke] no chunks returned — corpus is empty or retrieval is broken.");
+    process.exitCode = 1;
+    return;
+  }
+
+  for (const r of results) {
+    const preview = r.content.replace(/\s+/g, " ").slice(0, 200);
+    console.log(
+      JSON.stringify({
+        rank: r.rank,
+        score: Number(r.score.toFixed(4)),
+        sourceType: r.sourceType,
+        title: r.title,
+        content: preview + (r.content.length > 200 ? "…" : "")
+      })
+    );
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error("[smoke] failed:", err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/packages/db/src/embeddings/index.ts
+++ b/packages/db/src/embeddings/index.ts
@@ -1,0 +1,11 @@
+import { createOpenAIEmbeddingProvider } from "./openai.js";
+import type { EmbeddingProvider } from "./types.js";
+
+let provider: EmbeddingProvider | undefined;
+
+export function getEmbeddingProvider(): EmbeddingProvider {
+  return (provider ??= createOpenAIEmbeddingProvider());
+}
+
+export { createOpenAIEmbeddingProvider };
+export type { EmbeddingProvider };

--- a/packages/db/src/embeddings/openai.ts
+++ b/packages/db/src/embeddings/openai.ts
@@ -1,0 +1,76 @@
+import OpenAI from "openai";
+
+import { getEmbeddingEnv } from "../env.js";
+import type { EmbeddingProvider } from "./types.js";
+
+// OpenAI documents a 2048-input cap on embeddings; we chunk requests at this
+// boundary and concatenate results in order.
+const OPENAI_BATCH_CAP = 2048;
+
+export interface OpenAIEmbeddingProviderOptions {
+  model?: string;
+  dimensions?: number;
+}
+
+export function createOpenAIEmbeddingProvider(
+  options: OpenAIEmbeddingProviderOptions = {},
+): EmbeddingProvider {
+  const env = getEmbeddingEnv();
+  const model = options.model ?? env.EMBEDDING_MODEL;
+  const dimensions = options.dimensions ?? env.EMBEDDING_DIMENSIONS;
+
+  let client: OpenAI | undefined;
+
+  function getClient(): OpenAI {
+    if (client) return client;
+    // Batch ingestion is sensitive to transient 429/5xx; the SDK retries on
+    // both with exponential backoff. Timeout caps an individual request so a
+    // hung call doesn't stall the whole seed.
+    client = new OpenAI({
+      apiKey: env.OPENAI_API_KEY,
+      maxRetries: 3,
+      timeout: 30_000,
+    });
+    return client;
+  }
+
+  return {
+    model,
+    dimensions,
+    async embed(texts, signal) {
+      if (texts.length === 0) return [];
+
+      const openai = getClient();
+      const vectors: number[][] = [];
+
+      for (let i = 0; i < texts.length; i += OPENAI_BATCH_CAP) {
+        const batch = texts.slice(i, i + OPENAI_BATCH_CAP);
+        const response = await openai.embeddings.create(
+          {
+            model,
+            dimensions,
+            input: batch,
+          },
+          { signal },
+        );
+
+        if (response.data.length !== batch.length) {
+          throw new Error(
+            `OpenAI returned ${response.data.length} embeddings for a batch of ${batch.length}.`,
+          );
+        }
+
+        for (const [j, item] of response.data.entries()) {
+          if (item.embedding.length !== dimensions) {
+            throw new Error(
+              `OpenAI embedding at index ${i + j} has ${item.embedding.length} dimensions, expected ${dimensions}.`,
+            );
+          }
+          vectors.push(item.embedding);
+        }
+      }
+
+      return vectors;
+    },
+  };
+}

--- a/packages/db/src/embeddings/types.ts
+++ b/packages/db/src/embeddings/types.ts
@@ -1,0 +1,5 @@
+export interface EmbeddingProvider {
+  readonly model: string;
+  readonly dimensions: number;
+  embed(texts: string[], signal?: AbortSignal): Promise<number[][]>;
+}

--- a/packages/db/src/env.ts
+++ b/packages/db/src/env.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+// Split by responsibility so DB-only code never depends on embedding env.
+// Accessors are lazy and cache after first call — never evaluated at
+// import time.
+
+const databaseEnvSchema = z.object({
+  DATABASE_URL: z.string().url(),
+});
+
+const embeddingEnvSchema = z.object({
+  OPENAI_API_KEY: z.string().min(1),
+  EMBEDDING_MODEL: z.string().min(1).default("text-embedding-3-small"),
+  EMBEDDING_DIMENSIONS: z.coerce.number().int().positive().default(1536),
+});
+
+export type DatabaseEnv = z.infer<typeof databaseEnvSchema>;
+export type EmbeddingEnv = z.infer<typeof embeddingEnvSchema>;
+
+let dbCache: DatabaseEnv | undefined;
+let embedCache: EmbeddingEnv | undefined;
+
+export function getDatabaseEnv(): DatabaseEnv {
+  if (!dbCache) {
+    dbCache = parseOrThrow(databaseEnvSchema, "database");
+  }
+  return dbCache;
+}
+
+export function getEmbeddingEnv(): EmbeddingEnv {
+  if (!embedCache) {
+    embedCache = parseOrThrow(embeddingEnvSchema, "embedding");
+  }
+  return embedCache;
+}
+
+function parseOrThrow<T extends z.ZodTypeAny>(
+  schema: T,
+  label: string,
+): z.infer<T> {
+  const result = schema.safeParse(process.env);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `${i.path.join(".")}: ${i.message}`)
+      .join("; ");
+    throw new Error(
+      `Invalid ${label} environment for @portfolio/db: ${issues}`,
+    );
+  }
+  return result.data;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,5 +1,6 @@
 import { PrismaPg } from "@prisma/adapter-pg";
 
+import { getDatabaseEnv } from "./env.js";
 import { PrismaClient } from "./generated/prisma/client.js";
 
 const globalForPrisma = globalThis as unknown as {
@@ -7,13 +8,8 @@ const globalForPrisma = globalThis as unknown as {
 };
 
 function createPrismaClient(): PrismaClient {
-  const connectionString = process.env.DATABASE_URL;
-  if (!connectionString) {
-    throw new Error(
-      "DATABASE_URL is not set. The @portfolio/db client requires a Postgres connection string.",
-    );
-  }
-  const adapter = new PrismaPg({ connectionString });
+  const { DATABASE_URL } = getDatabaseEnv();
+  const adapter = new PrismaPg({ connectionString: DATABASE_URL });
   return new PrismaClient({ adapter });
 }
 

--- a/packages/db/src/knowledge/chunking.ts
+++ b/packages/db/src/knowledge/chunking.ts
@@ -1,0 +1,82 @@
+export interface ChunkOptions {
+  targetChars?: number;
+  overlapChars?: number;
+}
+
+export interface TextChunk {
+  chunkIndex: number;
+  content: string;
+  tokenCount: number;
+}
+
+const DEFAULT_TARGET = 1500;
+const DEFAULT_OVERLAP = 150;
+
+export function chunkText(content: string, opts: ChunkOptions = {}): TextChunk[] {
+  const targetChars = opts.targetChars ?? DEFAULT_TARGET;
+  const overlapChars = opts.overlapChars ?? DEFAULT_OVERLAP;
+
+  if (targetChars <= 0) {
+    throw new Error("chunkText: targetChars must be positive.");
+  }
+  if (overlapChars < 0 || overlapChars >= targetChars) {
+    throw new Error("chunkText: overlapChars must be >= 0 and strictly less than targetChars.");
+  }
+
+  const normalized = content.replace(/\r\n/g, "\n").trim();
+  if (normalized.length === 0) return [];
+
+  if (normalized.length <= targetChars) {
+    return [
+      {
+        chunkIndex: 0,
+        content: normalized,
+        tokenCount: estimateTokens(normalized)
+      }
+    ];
+  }
+
+  const chunks: TextChunk[] = [];
+  let cursor = 0;
+  let chunkIndex = 0;
+
+  while (cursor < normalized.length) {
+    const end = Math.min(cursor + targetChars, normalized.length);
+    const slice = normalized.slice(cursor, end);
+
+    let breakAt = slice.length;
+    if (end < normalized.length) {
+      breakAt = findBreakpoint(slice);
+    }
+
+    const piece = slice.slice(0, breakAt).trim();
+    if (piece.length > 0) {
+      chunks.push({
+        chunkIndex,
+        content: piece,
+        tokenCount: estimateTokens(piece)
+      });
+      chunkIndex += 1;
+    }
+
+    if (end >= normalized.length) break;
+
+    const advance = Math.max(breakAt - overlapChars, 1);
+    cursor += advance;
+  }
+
+  return chunks;
+}
+
+function findBreakpoint(slice: string): number {
+  const candidates = [slice.lastIndexOf("\n\n"), slice.lastIndexOf("\n"), slice.lastIndexOf(". ")];
+  const minViable = Math.floor(slice.length * 0.5);
+  for (const idx of candidates) {
+    if (idx >= minViable) return idx + 1;
+  }
+  return slice.length;
+}
+
+function estimateTokens(text: string): number {
+  return Math.max(1, Math.ceil(text.length / 4));
+}

--- a/packages/db/src/knowledge/chunks.ts
+++ b/packages/db/src/knowledge/chunks.ts
@@ -1,0 +1,73 @@
+import { randomUUID } from "node:crypto";
+
+import pgvector from "pgvector";
+
+import { prisma, Prisma } from "../index.js";
+import type { TextChunk } from "./chunking.js";
+
+const EXPECTED_DIMENSIONS = 1536;
+
+export interface StoredChunkInput extends TextChunk {
+  title?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface ReplaceChunksResult {
+  inserted: number;
+}
+
+export async function replaceDocumentChunks(
+  documentId: string,
+  chunks: StoredChunkInput[],
+  embeddings: number[][]
+): Promise<ReplaceChunksResult> {
+  if (chunks.length !== embeddings.length) {
+    throw new Error(`replaceDocumentChunks: got ${chunks.length} chunks but ${embeddings.length} embeddings.`);
+  }
+
+  for (const [i, vec] of embeddings.entries()) {
+    if (vec.length !== EXPECTED_DIMENSIONS) {
+      throw new Error(
+        `replaceDocumentChunks: embedding at index ${i} has ${vec.length} dimensions, expected ${EXPECTED_DIMENSIONS}.`
+      );
+    }
+    for (const [j, n] of vec.entries()) {
+      if (!Number.isFinite(n)) {
+        throw new Error(`replaceDocumentChunks: embedding[${i}][${j}] is not finite.`);
+      }
+    }
+  }
+
+  return prisma.$transaction(async (tx) => {
+    await tx.$executeRaw`DELETE FROM "DocumentChunk" WHERE "documentId" = ${documentId}`;
+
+    if (chunks.length === 0) {
+      return { inserted: 0 };
+    }
+
+    for (const [i, chunk] of chunks.entries()) {
+      const embedding = embeddings[i]!;
+      const vectorLiteral = pgvector.toSql(embedding) as string;
+      const metadataJson = chunk.metadata == null ? Prisma.DbNull : (chunk.metadata as Prisma.InputJsonValue);
+
+      await tx.$executeRaw`
+        INSERT INTO "DocumentChunk" (
+          "id", "documentId", "chunkIndex", "title", "content",
+          "embedding", "tokenCount", "metadata", "createdAt"
+        ) VALUES (
+          ${randomUUID()},
+          ${documentId},
+          ${chunk.chunkIndex}::int,
+          ${chunk.title ?? null},
+          ${chunk.content},
+          ${vectorLiteral}::vector(1536),
+          ${chunk.tokenCount}::int,
+          ${metadataJson}::jsonb,
+          NOW()
+        )
+      `;
+    }
+
+    return { inserted: chunks.length };
+  });
+}

--- a/packages/db/src/knowledge/documents.ts
+++ b/packages/db/src/knowledge/documents.ts
@@ -1,0 +1,53 @@
+import { createHash } from "node:crypto";
+
+import type { KnowledgeDocumentInput } from "@portfolio/contracts/knowledge";
+
+import { prisma, Prisma, type Document } from "../index.js";
+
+export function computeContentHash(content: string): string {
+  const normalized = content.trim().replace(/[ \t]+\n/g, "\n");
+  return createHash("sha256").update(normalized, "utf8").digest("hex");
+}
+
+export interface UpsertDocumentResult {
+  document: Document;
+  changed: boolean;
+  created: boolean;
+}
+
+export async function upsertDocument(input: KnowledgeDocumentInput): Promise<UpsertDocumentResult> {
+  const contentHash = computeContentHash(input.content);
+
+  const existing = await prisma.document.findFirst({
+    where: input.sourceUri
+      ? { sourceType: input.sourceType, sourceUri: input.sourceUri }
+      : { sourceType: input.sourceType, sourceUri: null, title: input.title },
+    orderBy: { updatedAt: "desc" }
+  });
+
+  if (existing && existing.contentHash === contentHash) {
+    return { document: existing, changed: false, created: false };
+  }
+
+  const metadata = input.metadata == null ? Prisma.JsonNull : (input.metadata as Prisma.InputJsonValue);
+  const sharedFields = {
+    title: input.title,
+    sourceUri: input.sourceUri ?? null,
+    contentHash,
+    metadata,
+    isActive: true
+  };
+
+  if (existing) {
+    const document = await prisma.document.update({
+      where: { id: existing.id },
+      data: sharedFields
+    });
+    return { document, changed: true, created: false };
+  }
+
+  const document = await prisma.document.create({
+    data: { ...sharedFields, sourceType: input.sourceType }
+  });
+  return { document, changed: true, created: true };
+}

--- a/packages/db/src/knowledge/retrieve.ts
+++ b/packages/db/src/knowledge/retrieve.ts
@@ -1,0 +1,81 @@
+import pgvector from "pgvector";
+
+import { RetrievalQuerySchema, RetrievedChunkSchema, type RetrievalQuery, type RetrievedChunk } from "@portfolio/contracts/knowledge";
+
+import { getEmbeddingProvider } from "../embeddings/index.js";
+import { prisma } from "../index.js";
+
+export interface RetrieveChunksInput extends RetrievalQuery {
+  embedding?: number[];
+}
+
+interface RetrievalRow {
+  chunkId: string;
+  documentId: string;
+  title: string | null;
+  content: string;
+  sourceType: string;
+  score: number;
+}
+
+export async function retrieveChunks(input: RetrieveChunksInput): Promise<RetrievedChunk[]> {
+  const parsed = RetrievalQuerySchema.parse({
+    query: input.query,
+    topK: input.topK,
+    sourceType: input.sourceType,
+    minSimilarity: input.minSimilarity
+  });
+
+  const embedding = input.embedding ?? (await embedOne(parsed.query));
+  const vectorLiteral = pgvector.toSql(embedding) as string;
+  const sourceType = parsed.sourceType ?? null;
+  const minSimilarity = parsed.minSimilarity ?? null;
+
+  const rows = await prisma.$queryRaw<RetrievalRow[]>`
+    SELECT c."id"          AS "chunkId",
+           c."documentId"  AS "documentId",
+           c."title"       AS "title",
+           c."content"     AS "content",
+           d."sourceType"  AS "sourceType",
+           1 - (c."embedding" <=> ${vectorLiteral}::vector(1536))::float8 AS "score"
+      FROM "DocumentChunk" c
+      JOIN "Document" d ON d."id" = c."documentId"
+     WHERE d."isActive" = true
+       AND c."embedding" IS NOT NULL
+       AND (${sourceType}::text IS NULL OR d."sourceType" = ${sourceType}::text)
+       AND (
+         ${minSimilarity}::float8 IS NULL
+         OR 1 - (c."embedding" <=> ${vectorLiteral}::vector(1536))::float8 >= ${minSimilarity}::float8
+       )
+     ORDER BY c."embedding" <=> ${vectorLiteral}::vector(1536) ASC
+     LIMIT ${parsed.topK}::int
+  `;
+
+  return rows.map((row, index) =>
+    RetrievedChunkSchema.parse({
+      documentId: row.documentId,
+      chunkId: row.chunkId,
+      title: row.title,
+      content: row.content,
+      sourceType: row.sourceType,
+      score: clampUnit(row.score),
+      rank: index + 1
+    })
+  );
+}
+
+async function embedOne(text: string): Promise<number[]> {
+  const provider = getEmbeddingProvider();
+  const [vector] = await provider.embed([text]);
+  if (!vector) {
+    throw new Error("Embedding provider returned no vector for query.");
+  }
+  return vector;
+}
+
+function clampUnit(value: number): number {
+  if (Number.isNaN(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,12 @@ importers:
 
   packages/db:
     dependencies:
+      '@portfolio/content':
+        specifier: workspace:*
+        version: link:../portfolio-content
+      '@portfolio/contracts':
+        specifier: workspace:*
+        version: link:../contracts
       '@prisma/adapter-pg':
         specifier: ^7.8.0
         version: 7.8.0
@@ -124,6 +130,15 @@ importers:
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
+      openai:
+        specifier: ^5.0.0
+        version: 5.23.2(zod@3.25.76)
+      pgvector:
+        specifier: ^0.2.0
+        version: 0.2.1
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       '@portfolio/typescript-config':
         specifier: workspace:*
@@ -2219,6 +2234,18 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
+  openai@5.23.2:
+    resolution: {integrity: sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -2292,6 +2319,10 @@ packages:
 
   pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
+  pgvector@0.2.1:
+    resolution: {integrity: sha512-nKaQY9wtuiidwLMdVIce1O3kL0d+FxrigCVzsShnoqzOSaWWWOvuctb/sYwlai5cTwwzRSNa+a/NtN2kVZGNJw==}
+    engines: {node: '>= 18'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -4967,6 +4998,10 @@ snapshots:
 
   ohash@2.0.11: {}
 
+  openai@5.23.2(zod@3.25.76):
+    optionalDependencies:
+      zod: 3.25.76
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -5048,6 +5083,8 @@ snapshots:
   pgpass@1.0.5:
     dependencies:
       split2: 4.2.0
+
+  pgvector@0.2.1: {}
 
   picocolors@1.1.1: {}
 

--- a/prompt-build-knowledge-ingestion-and-retrieval.md
+++ b/prompt-build-knowledge-ingestion-and-retrieval.md
@@ -1,0 +1,336 @@
+We already have the initial Prisma/Postgres/pgvector data model and migration in place.
+
+Build the next vertical foundation: knowledge ingestion and retrieval.
+
+## Goal
+
+Create the minimal infrastructure needed to seed portfolio knowledge into the
+database, split it into chunks, generate embeddings, store those embeddings in
+`DocumentChunk`, and retrieve relevant chunks through pgvector similarity
+search.
+
+## Scope
+
+Work only on the database/knowledge foundation.
+
+- Do not build API routes.
+- Do not build frontend.
+- Do not build LangGraph agent logic.
+- Do not build Twilio handlers.
+- Do not add Kubernetes/AWS deployment code.
+- Do not add the deferred models yet (`DocumentSource`,
+  `KnowledgeIngestionJob`, `EvaluationRun`, `EvaluationResult`).
+- Do not add a queue, worker, MMR/reranker, or embedding cache yet.
+
+## Existing architecture you must align with
+
+The repo is a pnpm + Turborepo monorepo (Next 16 / React 19 / Tailwind v4).
+Relevant facts you must respect — read these files before writing code:
+
+- `packages/db/prisma/schema.prisma` — current models: `Conversation`,
+  `Message`, `Document`, `DocumentChunk`, `AgentTrace`, `AgentStep`,
+  `RetrievedContext`, `ChannelEvent`.
+- `packages/db/prisma/migrations/20260524004058_init/migration.sql` — enables
+  the `vector` extension and creates a partial HNSW index on
+  `DocumentChunk.embedding` using `vector_cosine_ops` (only where
+  `embedding IS NOT NULL`).
+- `packages/db/src/index.ts` — exports a singleton `prisma` built on the
+  Prisma 7 `PrismaPg` adapter, plus re-exports the generated client.
+  **All new code must import this `prisma` instance — do not instantiate a
+  new `PrismaClient`.**
+- `packages/db/prisma.config.ts` — Prisma 7 config; loads `dotenv/config`.
+- `packages/db/package.json` — ESM (`"type": "module"`), main/types point
+  directly at `./src/index.ts` (there is no compiled `dist/`), uses `tsx`
+  for scripts and depends on `dotenv`.
+- `packages/db/src/generated/prisma/client.js` — generated client output
+  location; imports use the `.js` extension because of NodeNext ESM.
+- `packages/contracts/src/{common,channel,twilio}.ts` and
+  `packages/contracts/package.json` — Zod schemas + inferred TS types
+  pattern used elsewhere. The `.` and `./twilio` subpath exports show the
+  convention for adding new public entrypoints.
+- `docs/architecture.md` — explains the contract / db / agent / api split.
+- `packages/typescript-config/base.json` — `strict: true`,
+  `noUncheckedIndexedAccess: true`, `module: "NodeNext"`, `target: "ES2022"`.
+  Indexed access returns `T | undefined`; handle it.
+
+`DocumentChunk.embedding` is `Unsupported("vector(1536)")?`, which is why raw
+SQL is required for vector reads/writes — Prisma cannot bind or project that
+column through the typed client.
+
+## Architectural constraints (non-negotiable)
+
+- Default embedding model: `text-embedding-3-small` (1536 dims, matches the
+  schema). Model name and dimension must be configurable via env vars; the
+  implementation must throw a clear error if a returned vector's length does
+  not match the configured dimension.
+- Keep provider-specific embedding code behind a small abstraction so the
+  provider (OpenAI today, Anthropic / Voyage / Cohere later) can be swapped
+  without touching ingestion or retrieval call sites.
+- API keys come from environment variables. No secrets in code or git.
+- Do not call embeddings, the OpenAI client, or Prisma at module load —
+  only inside explicit functions/scripts. Provider clients must be lazy.
+- Prefer parameterized raw SQL via `Prisma.sql` / `prisma.$queryRaw` /
+  `prisma.$executeRaw` for any column touching `vector(1536)`. Never build
+  SQL by string concatenation with user-supplied values.
+- Reuse the singleton `prisma` from `@portfolio/db`. Do not new up a client.
+- Shared cross-package types (knowledge inputs, retrieved chunk shape) live
+  in `@portfolio/contracts` as Zod schemas + inferred TS types — same pattern
+  as `channel.ts`. The agent and api packages will consume them later.
+- Internal db-package implementation types stay inside `packages/db/src`.
+- Do not redesign the existing schema. If you genuinely believe a schema
+  change is required, stop and explain why before making it.
+
+## Required capabilities
+
+### 1. Shared contracts (`packages/contracts`)
+
+Add `packages/contracts/src/knowledge.ts` with Zod schemas and inferred
+types for the cross-package surface only:
+
+- `KnowledgeSourceTypeSchema` — `z.enum([...])` of the source types used by
+  the seed (e.g. `"profile"`, `"project"`, `"experience"`, `"skills"`,
+  `"writing"`). Keep this list small and obvious; it can grow later.
+- `KnowledgeDocumentInputSchema` — `{ title, sourceType, sourceUri?,
+  content, metadata? }` with `NonEmptyStringSchema` where appropriate.
+- `RetrievedChunkSchema` — `{ documentId, chunkId, title, content,
+  sourceType, score, rank }` (`score` is cosine similarity in `[0, 1]`,
+  `rank` is 1-indexed).
+- `RetrievalQuerySchema` — `{ query, topK?, sourceType?, minSimilarity? }`
+  with sensible bounds (`topK` int 1..50 default 5,
+  `minSimilarity` 0..1 optional).
+
+Export these from `packages/contracts/src/index.ts` and also as a subpath
+`./knowledge` in `packages/contracts/package.json` exports (mirror the
+`./twilio` entry).
+
+### 2. Knowledge document upsert (`packages/db`)
+
+Add `packages/db/src/knowledge/documents.ts`:
+
+- `computeContentHash(content: string): string` — SHA-256 hex of the
+  normalized content (e.g. trim + collapse trailing whitespace). Use
+  `node:crypto`; do not pull in a hashing dependency.
+- `upsertDocument(input: KnowledgeDocumentInput): Promise<{ document,
+  changed: boolean }>` — looks up by `(sourceType, sourceUri)` if
+  `sourceUri` is present, else by `(sourceType, title)`. Returns
+  `changed: false` when the row exists and `contentHash` is unchanged so
+  callers can skip re-chunking and re-embedding.
+
+Do not silently swallow Prisma errors.
+
+### 3. Chunking (`packages/db`)
+
+Add `packages/db/src/knowledge/chunking.ts`:
+
+- A single function `chunkText(content, opts?)` returning
+  `Array<{ chunkIndex, content, tokenCount }>`.
+- Defaults: target ~1500 chars (~375 tokens) per chunk, ~150 char overlap.
+  Make these overridable via opts.
+- Split preference order: paragraph boundary (`\n\n`) → line (`\n`) →
+  sentence (`. `) → hard cut. Keep it short and readable; no semantic
+  chunking, no tokenizer dependency.
+- Trim each chunk; skip empty or whitespace-only output.
+- `chunkIndex` is sequential starting at 0. Estimate `tokenCount` as
+  `Math.ceil(content.length / 4)` (documented heuristic, not exact).
+- Pure function — no I/O, no globals, deterministic.
+
+### 4. Embedding provider abstraction (`packages/db`)
+
+Add `packages/db/src/embeddings/`:
+
+- `types.ts` — `EmbeddingProvider` interface:
+  ```ts
+  interface EmbeddingProvider {
+    readonly model: string;
+    readonly dimensions: number;
+    embed(texts: string[], signal?: AbortSignal): Promise<number[][]>;
+  }
+  ```
+- `openai.ts` — `createOpenAIEmbeddingProvider({ apiKey?, model?,
+  dimensions? })`. Uses the official `openai` SDK (add as a dependency
+  to `packages/db`). Reads `OPENAI_API_KEY`, `EMBEDDING_MODEL`
+  (default `text-embedding-3-small`), and `EMBEDDING_DIMENSIONS`
+  (default `1536`) from env when not provided. Throws a clear error
+  if `OPENAI_API_KEY` is missing the first time `embed()` is called.
+- `index.ts` — exports a `getEmbeddingProvider()` factory that returns
+  the configured provider singleton (lazy; OpenAI today).
+
+Requirements:
+
+- Batch inputs in a single API call when possible; if the OpenAI batch
+  size cap is hit, chunk the request and concatenate results in order.
+- Validate every returned vector has exactly `dimensions` numbers;
+  throw on mismatch (with the offending index).
+- Set a reasonable request timeout via `AbortSignal`.
+- No retries with hidden backoff — fail fast; we'll add retry policy
+  when we wire the ingestion job model.
+
+### 5. Persist chunks with embeddings (`packages/db`)
+
+Add `packages/db/src/knowledge/chunks.ts`:
+
+- `replaceDocumentChunks(documentId, chunks, embeddings)` — runs inside
+  a Prisma transaction:
+  1. `DELETE FROM "DocumentChunk" WHERE "documentId" = $1`
+  2. Insert each chunk via raw SQL, binding the embedding as a
+     `vector(1536)` literal. Format: build the string
+     `'[v1,v2,...,vN]'` and cast `$N::vector(1536)` in the query
+     (`Prisma.sql` parameterization). Optionally use the `pgvector`
+     npm package's `toSql()` helper if you add the dep; otherwise
+     hand-roll the literal with strict `Number.isFinite` validation.
+  3. Update `Document.updatedAt`/`contentHash` if not already handled
+     by the upsert step.
+- Insert in a single multi-row statement when feasible, otherwise loop;
+  prefer clarity over micro-optimization.
+- Reject any embedding whose length is not 1536 before issuing SQL.
+
+### 6. Similarity retrieval (`packages/db`)
+
+Add `packages/db/src/knowledge/retrieve.ts`:
+
+- `retrieveChunks(input: RetrievalQuery & { embedding?: number[] }):
+  Promise<RetrievedChunk[]>`.
+- If `embedding` is not provided, embed `query` via
+  `getEmbeddingProvider()`.
+- Raw SQL pattern:
+  ```sql
+  SELECT c."id" AS "chunkId",
+         c."documentId",
+         c."title",
+         c."content",
+         d."sourceType",
+         1 - (c."embedding" <=> $1::vector(1536)) AS "score"
+    FROM "DocumentChunk" c
+    JOIN "Document" d ON d."id" = c."documentId"
+   WHERE d."isActive" = true
+     AND c."embedding" IS NOT NULL
+     AND ($2::text IS NULL OR d."sourceType" = $2)
+     AND ($3::float8 IS NULL OR 1 - (c."embedding" <=> $1::vector(1536)) >= $3)
+   ORDER BY c."embedding" <=> $1::vector(1536) ASC
+   LIMIT $4;
+  ```
+- Assign `rank` (1-indexed) in JS from the result order.
+- Return values must conform to `RetrievedChunkSchema` (parse with Zod
+  before returning so contract drift is caught immediately).
+
+### 7. Seed script (`packages/db`)
+
+Add `packages/db/scripts/seed-knowledge.ts` and a sibling
+`packages/db/scripts/seed-knowledge-data.ts` holding the placeholder
+content as an exported array, so the content is easy to edit without
+touching the runner.
+
+Required placeholder source types (realistic but obviously placeholder):
+
+- professional summary
+- technical skills
+- AI engineering positioning
+- selected projects (2–3 distinct entries)
+- leadership / architecture experience
+
+Runner behavior:
+
+- `import "dotenv/config"` at the top.
+- For each document: `upsertDocument` → if `changed === false` and chunks
+  already exist, skip; otherwise `chunkText` → batch-embed all chunks for
+  that doc in one call → `replaceDocumentChunks`.
+- Print one structured summary line per document
+  (`{ title, status: "inserted" | "updated" | "skipped", chunks, ms }`)
+  and a final totals line. No emojis.
+- Exit non-zero on any failure.
+
+### 8. Smoke test script (`packages/db`)
+
+Add `packages/db/scripts/smoke-retrieval.ts`:
+
+- `import "dotenv/config"`.
+- Run a hard-coded query such as
+  `"What kind of AI systems has David built?"`.
+- Print the top retrieved chunks with `{ rank, score, title,
+  sourceType, content (truncated to ~200 chars) }`.
+- Does not require the API server. Exit non-zero on error.
+
+### 9. Package scripts
+
+Update `packages/db/package.json` scripts, preserving the existing ones
+(`check-types`, `db:generate`, `db:migrate`, `db:studio`):
+
+- `"seed:knowledge": "tsx scripts/seed-knowledge.ts"`
+- `"smoke:retrieval": "tsx scripts/smoke-retrieval.ts"`
+
+Add new dependencies:
+
+- `openai` (latest) — runtime dep of `packages/db`.
+- `@portfolio/contracts: workspace:*` — runtime dep of `packages/db`
+  (consumed by knowledge/retrieve.ts for response validation).
+- `zod` — only if you find you need it directly inside `packages/db`;
+  prefer re-exporting via `@portfolio/contracts`.
+
+Note: there is **no** `build` script in `packages/db` (the package is
+consumed as TS source). Do not add one.
+
+### 10. Documentation
+
+Add or update `packages/db/README.md` covering:
+
+- `DATABASE_URL` and how docker-compose provides it locally.
+- `OPENAI_API_KEY`, `EMBEDDING_MODEL`, `EMBEDDING_DIMENSIONS`.
+- `pnpm --filter @portfolio/db db:generate` after schema or generator
+  changes.
+- `pnpm --filter @portfolio/db db:migrate` to apply migrations.
+- `pnpm --filter @portfolio/db seed:knowledge`.
+- `pnpm --filter @portfolio/db smoke:retrieval`.
+- Why raw SQL is used for vector writes/reads (the
+  `Unsupported("vector(1536)")` constraint), and the cosine-distance
+  convention (`<=>` operator, similarity = `1 - distance`).
+- Note that changing `EMBEDDING_DIMENSIONS` requires a schema migration
+  to the `vector(N)` column and re-embedding all chunks.
+
+If a `.env.example` does not already exist at the repo root or in
+`packages/db`, add one in `packages/db` listing the required vars
+(values left blank).
+
+## Quality requirements
+
+- Clean and modular: small files, single responsibility, no leaky
+  abstractions across the contracts/db boundary.
+- No `any`; prefer explicit types or `unknown`. Honor
+  `noUncheckedIndexedAccess` — index access returns `T | undefined`.
+- ESM imports use `.js` extensions (NodeNext) — including imports of
+  generated Prisma output and intra-package files.
+- No new dependencies beyond `openai` (and optionally `pgvector`).
+- Surface real error messages — missing env vars, dimension mismatch,
+  network failures, transaction failures. Never swallow.
+- Do not add a queue, worker, API route, LangGraph node, or Twilio
+  integration in this slice.
+- Do not add deferred models.
+- Do not introduce a test framework — the smoke script is the manual
+  verification path for now.
+
+## Acceptance criteria
+
+- `pnpm --filter @portfolio/contracts check-types` passes.
+- `pnpm --filter @portfolio/db check-types` passes.
+- `pnpm --filter @portfolio/db db:generate` still passes.
+- `pnpm --filter @portfolio/db seed:knowledge` seeds portfolio
+  documents and chunks against a local Postgres+pgvector started via
+  the existing `docker-compose.yml`, and is idempotent on re-run.
+- `pnpm --filter @portfolio/db smoke:retrieval` returns relevant
+  chunks ranked by cosine similarity.
+- `RetrievedChunkSchema.parse(...)` succeeds on every result returned
+  by `retrieveChunks`.
+- The implementation is ready to be consumed by the future
+  `packages/agent` and `apps/api` without changes to public shapes.
+
+## After implementation
+
+1. List every file created or modified, grouped by package.
+2. Summarize the ingestion flow (upsert → chunk → embed → store) and
+   the retrieval flow (embed query → cosine search → rank → contract
+   parse) in a few lines each.
+3. Explain exactly how vector writes and vector search are handled
+   given Prisma's `Unsupported("vector(1536)")` — show the SQL shape
+   used for inserts and for the similarity query.
+4. Call out any deviations from this prompt and why.
+5. Stop. Do not proceed to LangGraph, API, frontend, or Twilio until
+   I approve.

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://turborepo.dev/schema.json",
   "ui": "tui",
+  "//": "globalEnv lists cross-cutting vars that can affect any task's output. Coarse-grained for this 3-package repo; refine via per-task `env` once tasks diverge meaningfully in what they read.",
+  "globalEnv": [
+    "DATABASE_URL",
+    "OPENAI_API_KEY",
+    "EMBEDDING_MODEL",
+    "EMBEDDING_DIMENSIONS"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

This PR delivers two related vertical slices in one diff:

1. **Knowledge ingestion + retrieval pipeline** — the next foundation on top of the schema from #5. Documents are upserted (SHA-256 `contentHash` idempotency), text is chunked, embeddings are generated via a pluggable provider, chunks are written through `prisma.$transaction` with `pgvector.toSql()` bound as `vector(1536)`, and retrieval runs a parameterized cosine-similarity raw query over the existing partial HNSW index. Output is Zod-validated.
2. **Env consolidation** — single root `.env.example` as the dev manifest, typed split accessors (`getDatabaseEnv()` / `getEmbeddingEnv()`) so DB-only commands never require `OPENAI_API_KEY`, Node 20+ `--env-file` for script entry points, explicit-path dotenv for `prisma.config.ts`, and `turbo.json` `globalEnv` for cache correctness. Production-aware: runtime code reads `process.env` through the same validated layer regardless of whether it came from a local `.env` or an ECS task-def / Secrets Manager injection.

## Highlights

**`packages/contracts`**
- `src/knowledge.ts` — `KnowledgeSourceType`, `KnowledgeDocumentInput`, `RetrievedChunk`, `RetrievalQuery` Zod schemas + types
- Exposed via `./knowledge` subpath mirroring the existing `./twilio` entry

**`packages/db`**
- `src/env.ts` — Zod-validated split accessors; lazy + cached; field-level errors
- `src/embeddings/{types,openai,index}.ts` — provider interface + OpenAI implementation with batching, dimension validation, AbortSignal, lazy client
- `src/knowledge/{documents,chunking,chunks,retrieve}.ts` — upsert, chunking, transactional chunk replacement, cosine retrieval
- `scripts/seed-knowledge.ts` — idempotent runner with canonical-seed pruning (only touches rows tagged `metadata.source ∈ {existing_portfolio, dev_fixture}`)
- `scripts/seed-knowledge-data.ts` — real portfolio content extracted verbatim from `apps/web/data/projects.ts` and `apps/web/app/{about,contact,page}.tsx`; one clearly-labeled `dev_fixture` placeholder for the AI-positioning gap
- `scripts/smoke-retrieval.ts` — hard-coded query, prints ranked output
- `prisma.config.ts` — loads root `.env` via explicit `path.resolve(import.meta.dirname, "../../.env")`
- `README.md` — env section rewritten to point at root `.env`, documents split accessors, includes Production subsection covering ECS/EKS + Secrets Manager + RDS-with-pgvector
- New deps: `openai`, `pgvector`, `zod`, `@portfolio/contracts`

**Cross-cutting**
- Root `.env.example` extended with `OPENAI_API_KEY`, `EMBEDDING_MODEL`, `EMBEDDING_DIMENSIONS`. `DATABASE_URL` switched from `${VAR}` interpolation to literal (Node's `--env-file` and `dotenv` do not expand variables — verified) with a comment block tying it to `POSTGRES_*`
- Root `engines.node` bumped from `>=18` to `>=20.11`
- `turbo.json` adds `globalEnv: ["DATABASE_URL", "OPENAI_API_KEY", "EMBEDDING_MODEL", "EMBEDDING_DIMENSIONS"]`
- `packages/db/.env.example` deleted (was the duplicate source of `DATABASE_URL`)

The full requirement spec for the ingestion slice is preserved at `prompt-build-knowledge-ingestion-and-retrieval.md` for context.

## Test plan

After `cp .env.example .env` at the repo root and pasting an `OPENAI_API_KEY`:

- [ ] `docker compose up -d` (or reuse existing `portfolio-postgres` container)
- [ ] `pnpm install` at the repo root
- [ ] `pnpm --filter @portfolio/db db:generate` succeeds
- [ ] `pnpm --filter @portfolio/db db:migrate` (no new migration expected)
- [ ] `pnpm --filter @portfolio/contracts check-types` passes
- [ ] `pnpm --filter @portfolio/db check-types` passes
- [ ] **DB-only positive (no `OPENAI_API_KEY` required):** blank the key in `.env`; `pnpm --filter @portfolio/db exec prisma migrate status` succeeds
- [ ] **Embedding positive:** restore the key; `pnpm --filter @portfolio/db seed:knowledge` runs to completion (twice — second run reports `skipped`/`pruned=0`)
- [ ] `pnpm --filter @portfolio/db smoke:retrieval` returns 5 ranked chunks with cosine similarity scores in `[0, 1]`, every row Zod-validated against `RetrievedChunkSchema`
- [ ] **Negative — missing `OPENAI_API_KEY`:** DB commands still work; embedding flow fails with `Invalid embedding environment for @portfolio/db: OPENAI_API_KEY: …`
- [ ] **Negative — `EMBEDDING_DIMENSIONS=abc`:** DB commands still work; embedding flow fails at the Zod coerce step
- [ ] **Negative — blank `DATABASE_URL`:** fails with `Invalid database environment for @portfolio/db: DATABASE_URL: Invalid url`
- [ ] **Drift check:** `grep -rn 'DATABASE_URL' .env* packages/*/.env*.example apps/*/.env*.example 2>/dev/null` returns exactly one definition (root `.env.example`)
- [ ] **Turbo `globalEnv` registered:** `pnpm exec turbo run check-types --dry-run | grep 'Global Env Vars'` shows the four vars
- [ ] Spot-check in `psql`: `SELECT COUNT(*) FROM "DocumentChunk" WHERE embedding IS NOT NULL;` matches the seeded chunk total