### PR TITLE
Add chat provider, heuristic grader, and prompt builders for @portfolio/agent (Phase 2)

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -17,6 +17,8 @@
     "smoke:agent": "tsx --env-file=../../.env scripts/smoke-agent.ts"
   },
   "dependencies": {
+    "@portfolio/contracts": "workspace:*",
+    "openai": "^5.0.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/agent/src/grader/heuristic.ts
+++ b/packages/agent/src/grader/heuristic.ts
@@ -1,0 +1,78 @@
+import type { RetrievedChunk } from "@portfolio/contracts/knowledge";
+
+import type { ContextGrader, ContextVerdict } from "./types";
+
+export interface HeuristicGraderOptions {
+  scoreFloor?: number;
+  topScoreThreshold?: number;
+  meanScoreThreshold?: number;
+  minAcceptedCount?: number;
+}
+
+const DEFAULTS = {
+  scoreFloor: 0.55,
+  topScoreThreshold: 0.78,
+  meanScoreThreshold: 0.7,
+  minAcceptedCount: 1,
+} as const;
+
+export function createHeuristicGrader(
+  options: HeuristicGraderOptions = {},
+): ContextGrader {
+  const scoreFloor = options.scoreFloor ?? DEFAULTS.scoreFloor;
+  const topScoreThreshold =
+    options.topScoreThreshold ?? DEFAULTS.topScoreThreshold;
+  const meanScoreThreshold =
+    options.meanScoreThreshold ?? DEFAULTS.meanScoreThreshold;
+  const minAcceptedCount =
+    options.minAcceptedCount ?? DEFAULTS.minAcceptedCount;
+
+  return {
+    grade(chunks: RetrievedChunk[]): ContextVerdict {
+      if (chunks.length === 0) {
+        return {
+          label: "none",
+          accepted: [],
+          reason: "no chunks retrieved",
+        };
+      }
+
+      const filtered = chunks.filter((c) => c.score >= scoreFloor);
+      if (filtered.length === 0) {
+        return {
+          label: "none",
+          accepted: [],
+          reason: `all chunks below scoreFloor (${scoreFloor})`,
+        };
+      }
+
+      const topScore = filtered.reduce(
+        (acc, c) => (c.score > acc ? c.score : acc),
+        0,
+      );
+      const meanScore =
+        filtered.reduce((acc, c) => acc + c.score, 0) / filtered.length;
+
+      if (
+        topScore >= topScoreThreshold &&
+        meanScore >= meanScoreThreshold &&
+        filtered.length >= minAcceptedCount
+      ) {
+        return {
+          label: "good",
+          accepted: filtered,
+          topScore,
+          meanScore,
+        };
+      }
+
+      return {
+        label: "weak",
+        accepted: [],
+        topScore,
+        meanScore,
+        reason: "below confidence thresholds",
+      };
+    },
+  };
+}

--- a/packages/agent/src/grader/types.ts
+++ b/packages/agent/src/grader/types.ts
@@ -1,0 +1,15 @@
+import type { RetrievedChunk } from "@portfolio/contracts/knowledge";
+
+export type RelevanceLabel = "good" | "weak" | "none";
+
+export interface ContextVerdict {
+  label: RelevanceLabel;
+  accepted: RetrievedChunk[];
+  reason?: string;
+  topScore?: number;
+  meanScore?: number;
+}
+
+export interface ContextGrader {
+  grade(chunks: RetrievedChunk[]): ContextVerdict | Promise<ContextVerdict>;
+}

--- a/packages/agent/src/llm/index.ts
+++ b/packages/agent/src/llm/index.ts
@@ -1,0 +1,18 @@
+import { createOpenAIChatProvider } from "./openai";
+import type { ChatProvider } from "./types";
+
+let provider: ChatProvider | undefined;
+
+export function getChatProvider(): ChatProvider {
+  return (provider ??= createOpenAIChatProvider());
+}
+
+export { createOpenAIChatProvider };
+export type {
+  ChatProvider,
+  ChatMessage,
+  ChatRequest,
+  ChatResult,
+  ChatRole,
+  ChatUsage,
+} from "./types";

--- a/packages/agent/src/llm/openai.ts
+++ b/packages/agent/src/llm/openai.ts
@@ -1,0 +1,74 @@
+import OpenAI from "openai";
+
+import { getChatEnv } from "@/env";
+import type { ChatProvider } from "./types";
+
+export interface OpenAIChatProviderOptions {
+  model?: string;
+  temperature?: number;
+  maxTokens?: number;
+  timeoutMs?: number;
+}
+
+export function createOpenAIChatProvider(
+  options: OpenAIChatProviderOptions = {},
+): ChatProvider {
+  const env = getChatEnv();
+  const model = options.model ?? env.CHAT_MODEL;
+  const temperature = options.temperature ?? 0.2;
+  const maxTokens = options.maxTokens ?? env.CHAT_MAX_TOKENS;
+  const timeoutMs = options.timeoutMs ?? env.CHAT_TIMEOUT_MS;
+
+  let client: OpenAI | undefined;
+
+  function getClient(): OpenAI {
+    if (client) return client;
+    // Chat completions tolerate the same transient 429/5xx classes as
+    // embeddings; reuse the SDK's exponential backoff with a per-request
+    // timeout so a hung call doesn't stall the whole run.
+    client = new OpenAI({
+      apiKey: env.OPENAI_API_KEY,
+      maxRetries: 3,
+      timeout: timeoutMs,
+    });
+    return client;
+  }
+
+  return {
+    model,
+    async chat({ messages, temperature: t, maxTokens: m, signal }) {
+      const openai = getClient();
+
+      const response = await openai.chat.completions.create(
+        {
+          model,
+          temperature: t ?? temperature,
+          max_tokens: m ?? maxTokens,
+          messages,
+        },
+        { signal },
+      );
+
+      const choice = response.choices[0];
+      const content = choice?.message?.content;
+      if (!content) {
+        throw new Error(
+          `OpenAI chat completion returned no content for model ${model}.`,
+        );
+      }
+
+      return {
+        content,
+        model,
+        finishReason: choice?.finish_reason ?? undefined,
+        usage: response.usage
+          ? {
+              promptTokens: response.usage.prompt_tokens,
+              completionTokens: response.usage.completion_tokens,
+              totalTokens: response.usage.total_tokens,
+            }
+          : undefined,
+      };
+    },
+  };
+}

--- a/packages/agent/src/llm/types.ts
+++ b/packages/agent/src/llm/types.ts
@@ -1,0 +1,31 @@
+export type ChatRole = "system" | "user" | "assistant";
+
+export interface ChatMessage {
+  role: ChatRole;
+  content: string;
+}
+
+export interface ChatRequest {
+  messages: ChatMessage[];
+  temperature?: number;
+  maxTokens?: number;
+  signal?: AbortSignal;
+}
+
+export interface ChatUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+}
+
+export interface ChatResult {
+  content: string;
+  model: string;
+  finishReason?: string;
+  usage?: ChatUsage;
+}
+
+export interface ChatProvider {
+  readonly model: string;
+  chat(request: ChatRequest): Promise<ChatResult>;
+}

--- a/packages/agent/src/prompts/rewriteQuery.ts
+++ b/packages/agent/src/prompts/rewriteQuery.ts
@@ -1,0 +1,56 @@
+import type { RetrievedChunk } from "@portfolio/contracts/knowledge";
+
+export interface RewritePromptInput {
+  originalQuery: string;
+  currentQuery: string;
+  intent?: string;
+  weakChunks?: RetrievedChunk[];
+}
+
+export interface RewritePrompt {
+  system: string;
+  user: string;
+}
+
+const SYSTEM_PROMPT = [
+  "You rewrite user questions to improve semantic retrieval against David Bautista's portfolio knowledge base.",
+  "Preserve the original intent exactly. Do not invent names, projects, dates, or technologies that are not present in the input.",
+  "Make the query more specific and retrieval-friendly: prefer concrete nouns, expand vague pronouns, and surface implicit topics.",
+  "Output ONLY the rewritten query as a single line of plain text. No preamble, no quotes, no explanation.",
+].join("\n");
+
+export function buildRewritePrompt(input: RewritePromptInput): RewritePrompt {
+  const lines: string[] = [`Original question: ${input.originalQuery}`];
+
+  if (input.currentQuery && input.currentQuery !== input.originalQuery) {
+    lines.push(`Previous rewrite (also weak): ${input.currentQuery}`);
+  }
+
+  if (input.intent) {
+    lines.push(`Intent: ${input.intent}`);
+  }
+
+  if (input.weakChunks && input.weakChunks.length > 0) {
+    lines.push("");
+    lines.push(
+      "Retrieval with the previous query returned these weak results:",
+    );
+    for (const [i, chunk] of input.weakChunks.entries()) {
+      const title = chunk.title ?? "Untitled";
+      const preview = chunk.content.slice(0, 120).replace(/\s+/g, " ").trim();
+      lines.push(`[${i + 1}] ${title} — ${preview}`);
+    }
+    lines.push("");
+    lines.push(
+      "Rewrite to steer retrieval away from this drift while keeping the original intent.",
+    );
+  }
+
+  lines.push("");
+  lines.push("Rewritten query:");
+
+  return {
+    system: SYSTEM_PROMPT,
+    user: lines.join("\n"),
+  };
+}

--- a/packages/agent/src/prompts/systemPrompt.ts
+++ b/packages/agent/src/prompts/systemPrompt.ts
@@ -1,0 +1,46 @@
+import type { RetrievedChunk } from "@portfolio/contracts/knowledge";
+
+const BASE_INTRO = [
+  "You are the assistant for David Bautista's portfolio.",
+  "You speak to recruiters, interviewers, and prospective clients.",
+  "Stay concise, professional, and grounded in the provided context.",
+].join(" ");
+
+const RULES = [
+  "Answer ONLY using the numbered context below.",
+  "If the context does not fully cover the question, say so plainly and offer to follow up — do not guess.",
+  "Never invent projects, employers, dates, metrics, or technologies.",
+  "Prefer specific details from the context over generalities.",
+  "Keep answers tight: a few sentences unless the user asked for depth.",
+].join("\n- ");
+
+const EMPTY_CONTEXT_PROMPT = [
+  BASE_INTRO,
+  "",
+  "No relevant context is available for this question.",
+  "Tell the user you don't have enough information to answer and suggest they reach out to David directly.",
+  "Do not invent details.",
+].join("\n");
+
+export function buildSystemPrompt(acceptedChunks: RetrievedChunk[]): string {
+  if (acceptedChunks.length === 0) {
+    return EMPTY_CONTEXT_PROMPT;
+  }
+
+  const contextBlock = acceptedChunks
+    .map((chunk, i) => {
+      const title = chunk.title ?? "Untitled";
+      return `[${i + 1}] ${title}\n${chunk.content}`;
+    })
+    .join("\n\n");
+
+  return [
+    BASE_INTRO,
+    "",
+    "Context:",
+    contextBlock,
+    "",
+    "Rules:",
+    `- ${RULES}`,
+  ].join("\n");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,12 @@ importers:
 
   packages/agent:
     dependencies:
+      '@portfolio/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+      openai:
+        specifier: ^5.0.0
+        version: 5.23.2(zod@3.25.76)
       zod:
         specifier: ^3.23.8
         version: 3.25.76


### PR DESCRIPTION
## Summary
- Add `ChatProvider` abstraction with a lazy OpenAI implementation (`createOpenAIChatProvider` + memoized `getChatProvider`) mirroring the existing `EmbeddingProvider` shape — never constructs a client at import time, reads env only via `getChatEnv()`, `maxRetries: 3`, configurable timeout, forwards `AbortSignal`.
- Add `ContextGrader` interface + a deterministic, set-level `createHeuristicGrader` (defaults: `scoreFloor=0.55`, `topScoreThreshold=0.78`, `meanScoreThreshold=0.70`, `minAcceptedCount=1`). Returns `ContextVerdict | Promise<ContextVerdict>` so an LLM grader can drop in behind the same seam later.
- Add pure prompt builders: `buildSystemPrompt(acceptedChunks)` for grounded answers and `buildRewritePrompt({ originalQuery, currentQuery, intent?, weakChunks? })` returning `{ system, user }` for the upcoming rewrite node.
- Wire deps: `openai@^5.0.0` and `@portfolio/contracts` workspace dep on `@portfolio/agent`.

This is Phase 2 of `docs/03-build-agent-core-plan.md`. No LangGraph imports, no graph state/nodes, no DB writes, no `runAgent` entrypoint, no smoke script — those land in Phases 3 and 4. `src/index.ts` is intentionally untouched.

## Test plan
- [x] `pnpm install` — clean, no new resolutions beyond `openai 5.23.2`
- [x] `pnpm --filter @portfolio/agent check-types` — exit 0
- [x] `pnpm --filter @portfolio/agent lint` — exit 0
- [x] `grep -RE "@langchain/langgraph|@portfolio/db|process\.env" packages/agent/src/{llm,grader,prompts}` — no matches (no forbidden imports)
- [ ] Reviewer: confirm `createOpenAIChatProvider` does not construct an `OpenAI` client at import (client is built inside `getClient()` on first `chat()` call)
- [ ] Reviewer: confirm grader is pure and synchronous (no env reads, no LLM calls, no I/O)