### PR TITLE
Wire LangGraph CRAG workflow for @portfolio/agent (Phase 3)

### DIFF
--- a/docs/03-build-agent-core-plan.md
+++ b/docs/03-build-agent-core-plan.md
@@ -1,0 +1,343 @@
+# 03 — Build Agent Core: Implementation Plan
+
+This document is the approved implementation plan for the next architecture slice: building `packages/agent`, a LangGraph-TS Agentic RAG workflow that turns the existing `retrieveChunks()` layer into a grounded, self-correcting portfolio assistant.
+
+Full requirements live in `prompt.md` at the repo root and are non-negotiable. This plan splits the work into **four implementation phases**, ordered so each phase ends on a green floor (type-check + lint clean) before the next begins.
+
+---
+
+## Out of scope for this entire workflow
+
+The following are explicitly **NOT** part of this slice and must not be added in any of the four phases:
+
+- API routes (no `apps/api` work).
+- Frontend code (no `apps/web` changes related to the agent).
+- Twilio handlers or any provider-specific webhook code.
+- Prisma schema changes.
+- Database migrations.
+- Evaluation tables (`EvaluationRun`, `EvaluationResult`, etc.).
+- Ingestion-job tables (`KnowledgeIngestionJob`, etc.).
+- AWS, Kubernetes, ECS, deployment, infra-as-code changes.
+- Long-term / cross-request memory.
+- Auto-creation of `Conversation` or `Message` rows.
+- Tests / test framework introduction (validation is the smoke script + type-check + lint).
+- Build steps for `packages/agent` (it exports TypeScript source directly, matching `@portfolio/db` and `@portfolio/contracts`).
+
+---
+
+## Phase 1 — Public contracts & package foundation
+
+### Objective
+
+Lock in the public seams the future API and frontend will consume — agent request/response schemas in `@portfolio/contracts` — and create the empty `@portfolio/agent` package shell with all repo-convention configuration in place. No graph code yet.
+
+### Files created or modified
+
+- `packages/contracts/src/agent.ts` *(new)*
+- `packages/contracts/src/index.ts` *(modified — add `export * from "./agent"`)*
+- `packages/contracts/package.json` *(modified — add `./agent` subpath under `exports`, mirroring `./twilio` and `./knowledge`)*
+- `packages/agent/package.json` *(new)* — `name: @portfolio/agent`, `"type": "module"`, `main`/`types` pointing at `./src/index.ts`, no `build` script. Scripts: `check-types`, `lint`, `smoke:agent` (the script file itself comes in Phase 4 — the entry just needs to exist as a `package.json` script name).
+- `packages/agent/tsconfig.json` *(new)* — clones `packages/db/tsconfig.json`: extends `@portfolio/typescript-config/base.json`, `noEmit: true`, `paths: { "@/*": ["./src/*"] }`, includes `src/**/*.ts` and `scripts/**/*.ts`.
+- `packages/agent/eslint.config.js` *(new)* — clones `packages/db/eslint.config.js` (re-exports `@portfolio/eslint-config/base`).
+- `packages/agent/src/index.ts` *(new — placeholder barrel, can be empty or export only the type identity that comes from Phase 4)*.
+- `packages/agent/src/env.ts` *(new)* — `getChatEnv()` Zod-validated, lazy, cached accessor, mirroring `packages/db/src/env.ts`. Validates: `OPENAI_API_KEY` (required), `CHAT_MODEL` (default `gpt-4o-mini`), `CHAT_TIMEOUT_MS` (default `30000`), `CHAT_MAX_TOKENS` (default `1024`).
+- `turbo.json` *(modified)* — extend `globalEnv` with `CHAT_MODEL`, `CHAT_TIMEOUT_MS`, `CHAT_MAX_TOKENS`.
+- `.env.example` *(modified)* — append a "Chat completions" block with the three vars and their defaults.
+
+### Scope boundaries
+
+- Public-shape and packaging only. Define schemas, exports, scripts, configs, env validation.
+- No LangGraph code, no provider, no grader, no prompts, no nodes, no persistence helpers.
+- `getChatEnv()` is added in this phase because it's part of the package foundation (mirrors `getDatabaseEnv` / `getEmbeddingEnv` in `@portfolio/db`); nothing yet calls it.
+
+### Contract details (must be reused from existing schemas — do not redefine)
+
+In `packages/contracts/src/agent.ts`:
+
+- `AgentConfidenceSchema = z.enum(["high","medium","low"])`.
+- `AgentSourceSchema` — an **alias / re-export** of `RetrievedChunkSchema` from `./knowledge`. Do not redefine the chunk shape.
+- `AgentRequestSchema`:
+  - `conversationId?: NonEmptyStringSchema.optional()`
+  - `userId?: NonEmptyStringSchema.optional()`
+  - `message: NonEmptyStringSchema`
+  - `channel: ChannelSchema` (from `./common`)
+  - `metadata?: MetadataSchema.optional()`
+  - `maxRetries?: z.number().int().min(0).max(2).optional()`
+  - `topK?: z.number().int().min(1).max(20).optional()`
+- `AgentResponseSchema`:
+  - `answer: NonEmptyStringSchema`
+  - `confidence: AgentConfidenceSchema`
+  - `sources: z.array(AgentSourceSchema)`
+  - `traceId: NonEmptyStringSchema`
+  - `shouldEscalate: z.boolean()`
+  - `metadata?: MetadataSchema.optional()`
+- Inferred TS types (`AgentRequest`, `AgentResponse`, `AgentConfidence`, `AgentSource`) exported alongside the schemas.
+
+### Acceptance criteria
+
+- `@portfolio/contracts` exposes `AgentRequestSchema`, `AgentResponseSchema`, `AgentConfidenceSchema`, `AgentSourceSchema` plus inferred TS types, and they are importable from both `@portfolio/contracts` and `@portfolio/contracts/agent`.
+- `AgentSourceSchema` is not a parallel chunk shape — it is the same schema instance as `RetrievedChunkSchema`.
+- `@portfolio/agent` package exists, installs cleanly under pnpm, type-checks against an empty `src/`, and lints clean.
+- `getChatEnv()` exists, is lazy and cached, throws an actionable error when `OPENAI_API_KEY` is missing, and never executes at module import time.
+- `turbo.json` and `.env.example` include the new chat env vars.
+- No production code calls anything from `@portfolio/agent` yet.
+
+### Verification commands
+
+```
+pnpm install
+pnpm --filter @portfolio/contracts check-types
+pnpm --filter @portfolio/contracts lint
+pnpm --filter @portfolio/agent check-types
+pnpm --filter @portfolio/agent lint
+```
+
+### Must NOT be implemented in this phase
+
+- LangGraph (no import of `@langchain/langgraph` yet).
+- LLM provider (`src/llm/**`).
+- Grader (`src/grader/**`).
+- Prompts (`src/prompts/**`).
+- Graph nodes or wiring.
+- Persistence helpers.
+- Smoke script body (file may be referenced by the `smoke:agent` script entry, but its content is Phase 4).
+- `runAgent` entrypoint.
+- Any DB writes.
+
+---
+
+## Phase 2 — Model/provider abstraction & decision-support foundation
+
+### Objective
+
+Build the deterministic, dependency-free building blocks that the LangGraph workflow will call into: the chat provider abstraction (mirrors the existing `EmbeddingProvider` pattern), the heuristic context grader (behind a typed interface so it can be swapped for an LLM grader later), and the prompt builders for `generate_answer` and `rewrite_query`.
+
+### Files created or modified
+
+- `packages/agent/src/llm/types.ts` *(new)* — `ChatProvider` interface, `ChatMessage` and `ChatResult` types.
+- `packages/agent/src/llm/openai.ts` *(new)* — `createOpenAIChatProvider(options?)` factory. Lazy `OpenAI` client. Uses `getChatEnv()` from Phase 1. Calls `chat.completions.create` with model/temperature/max_tokens/timeout. Supports `AbortSignal`. SDK `maxRetries: 3`, `timeout: CHAT_TIMEOUT_MS`. No client construction at import time.
+- `packages/agent/src/llm/index.ts` *(new)* — `getChatProvider()` memoized singleton + re-export of `createOpenAIChatProvider` and `ChatProvider`.
+- `packages/agent/src/grader/types.ts` *(new)* — `ContextGrader` interface, `ContextVerdict` type, `RelevanceLabel = "good" | "weak" | "none"`.
+- `packages/agent/src/grader/heuristic.ts` *(new)* — `createHeuristicGrader(options?)`. Options with defaults: `scoreFloor=0.55`, `topScoreThreshold=0.78`, `meanScoreThreshold=0.70`, `minAcceptedCount=1`. Algorithm: filter chunks by `scoreFloor`; if none → `"none"`; else compute `top` and `mean`; if `top >= topScoreThreshold && mean >= meanScoreThreshold && count >= minAcceptedCount` → `"good"` with `accepted` set; else `"weak"` with `accepted: []`. Operates at the **set level**. Does NOT call the LLM.
+- `packages/agent/src/prompts/systemPrompt.ts` *(new)* — `buildSystemPrompt(acceptedChunks)`. Position the assistant as grounded on David's portfolio. Numbered chunk listing with source titles. Instructs the model to answer only from context, mention uncertainty when context is thin, never invent facts, stay concise and suitable for recruiters/interviewers/clients.
+- `packages/agent/src/prompts/rewriteQuery.ts` *(new)* — `buildRewritePrompt({ originalQuery, currentQuery, intent?, weakChunks? })`. Instructs the model to output ONLY the rewritten query, preserve intent, add no invented facts.
+- `packages/agent/package.json` *(modified)* — add runtime deps: `openai@^5.0.0`, `zod@^3.23.8`. `@portfolio/contracts: workspace:*` is added in this phase if not already (Phase 1 may have added it for env types, but the grader pulls in `RetrievedChunk` types so it's needed at the latest here).
+
+### Scope boundaries
+
+- Pure building blocks. No LangGraph imports. No DB writes. No state, nodes, or routing.
+- Heuristic grader does not consume the chat provider.
+- Prompt builders return strings; they do not call the model.
+
+### Acceptance criteria
+
+- `ChatProvider` interface mirrors `EmbeddingProvider` (`readonly model: string`, an async method that accepts an `AbortSignal`).
+- `createOpenAIChatProvider()` does not construct an `OpenAI` client at import time — only inside the first `chat()` call.
+- `getChatEnv()` is the only place env is read; the provider never touches `process.env` directly.
+- The OpenAI client is configured with `maxRetries: 3` and the configured timeout.
+- `createHeuristicGrader()` returns a `ContextGrader` with deterministic, pure `grade()` behavior. Calling it with no chunks returns `"none"`. Calling it with chunks above thresholds returns `"good"` and populates `accepted`. Otherwise returns `"weak"` with empty `accepted`.
+- Prompt builders produce stable strings (no LLM calls).
+- All new files type-check and lint clean.
+
+### Verification commands
+
+```
+pnpm --filter @portfolio/agent check-types
+pnpm --filter @portfolio/agent lint
+```
+
+### Must NOT be implemented in this phase
+
+- LangGraph imports anywhere in `packages/agent`.
+- Graph state, nodes, routing, wiring.
+- `runAgent` entrypoint.
+- Persistence helpers / Prisma writes.
+- Smoke script body.
+- LLM-based context grader (deferred — interface allows future swap).
+
+---
+
+## Phase 3 — LangGraph workflow (state, nodes, routing)
+
+### Objective
+
+Wire the cyclic CRAG-style LangGraph workflow: explicit typed state with reducers, six nodes implemented as dependency-injected closures, a conditional edge that routes after grading, and a real retry loop. The graph is buildable and `.invoke()`-able with injected fakes, but no DB writes yet — that lands in Phase 4.
+
+### Files created or modified
+
+- `packages/agent/src/deps.ts` *(new)* — `AgentDeps` type (`{ prisma, chatProvider, grader, retrieve }`) and `resolveDeps(overrides?: Partial<AgentDeps>): AgentDeps`. The DI seam. `retrieve` is a thin wrapper over `retrieveChunks()` from `@portfolio/db`. `prisma` is the singleton from `@portfolio/db`. `chatProvider` and `grader` come from Phase 2.
+- `packages/agent/src/graph/state.ts` *(new)* — `Annotation.Root({ ... })` declaring all state channels. Fields: `originalQuery`, `currentQuery`, `intent?`, `retrievedChunks`, `acceptedChunks`, `retryCount`, `maxRetries`, `relevanceLabel?`, `answer?`, `model`, `topK`, `metadata?`, `pendingSteps`, `traceId`. **`pendingSteps` declared with an explicit append reducer** `(prev, next) => [...prev, ...next]`; `retrievedChunks` / `acceptedChunks` / `retryCount` use default replace semantics. Also defines and exports `StepRecord` and `StepStatus` types.
+- `packages/agent/src/graph/routing.ts` *(new)* — `decisionRouter(state) → "generate_answer" | "rewrite_query" | "fallback"`. Implemented as a **conditional edge function**, not a node. Logic: `relevanceLabel === "good"` → generate; else if `retryCount < maxRetries` → rewrite; else → fallback. **Weak-after-retries always routes to fallback** — no best-effort generate path.
+- `packages/agent/src/graph/nodes/analyzeIntent.ts` *(new)* — `makeAnalyzeIntent(deps)` returning `(state) => Promise<Partial<GraphState>>`. **Pure transform**; normalizes `currentQuery` from `originalQuery` on first pass, captures lightweight intent, appends an `intent_classifier` step. Never short-circuits.
+- `packages/agent/src/graph/nodes/retrieveContext.ts` *(new)* — `makeRetrieveContext(deps)`. Calls `deps.retrieve({ query: state.currentQuery, topK: state.topK })`. **Replaces** `retrievedChunks` (no union with prior rounds). Appends a `retrieve_context` step.
+- `packages/agent/src/graph/nodes/gradeContext.ts` *(new)* — `makeGradeContext(deps)`. Calls `deps.grader.grade(state.retrievedChunks)`. Sets `relevanceLabel` and (on `"good"`) `acceptedChunks`. Appends a `grade_context` step including the verdict reason in metadata.
+- `packages/agent/src/graph/nodes/rewriteQuery.ts` *(new)* — `makeRewriteQuery(deps)`. Calls `deps.chatProvider.chat({ system: buildRewritePrompt(...), user: state.originalQuery })`. Updates `currentQuery`, increments `retryCount`. Appends a `rewrite_query` step including `metadata.rewrittenQuery` for downstream visibility.
+- `packages/agent/src/graph/nodes/generateAnswer.ts` *(new)* — `makeGenerateAnswer(deps)`. Calls `deps.chatProvider.chat({ system: buildSystemPrompt(state.acceptedChunks), user: state.originalQuery })`. Sets `answer` and `model`. Appends an `answer_generator` step.
+- `packages/agent/src/graph/nodes/fallback.ts` *(new)* — `makeFallback(deps)`. Returns a deterministic fallback string (no LLM call — robust to outage). Sets `answer` and `model`. Appends a `fallback_escalation` step.
+- `packages/agent/src/graph/index.ts` *(new)* — `buildAgentGraph(deps): { graph, defaultRecursionLimit }`. Wires `setEntryPoint("analyze_intent")`, the linear edges `analyze_intent → retrieve_context → grade_context`, the conditional edge from `grade_context` via `decisionRouter` into `{ generate_answer, rewrite_query, fallback }`, the loop edge `rewrite_query → retrieve_context`, and terminal edges `generate_answer → END` and `fallback → END`. Computes `defaultRecursionLimit = maxRetries * 4 + 4`.
+- `packages/agent/package.json` *(modified)* — add runtime dep `@langchain/langgraph@^0.2.74` and `@portfolio/db: workspace:*`.
+
+### Scope boundaries
+
+- Graph + nodes + routing only. Nodes receive their dependencies via closure; they never read `process.env`, never construct clients, never import the `prisma` singleton, never smuggle deps through state.
+- No DB writes from graph code. Nodes only append `StepRecord` entries to `pendingSteps` in state; persistence (in Phase 4) reads from state at the entrypoint boundary.
+- No `runAgent()` entrypoint yet. The graph is testable via `buildAgentGraph(deps).graph.invoke(initialState, { recursionLimit })` with hand-rolled deps.
+- No smoke script.
+
+### Dependency-injection guardrails (must hold at end of phase)
+
+- No file under `src/graph/nodes/**` imports from `@portfolio/db`, calls `getChatProvider()`, calls `createOpenAIChatProvider()`, references `process.env`, or imports `crypto`. Nodes get everything they need from `deps` and `state`.
+- `deps.retrieve` is the only seam through which `retrieveChunks()` is reachable from the graph.
+
+### LangGraph specifics (Annotation API)
+
+- Use `Annotation.Root({...})` to declare state channels with optional `reducer` and `default`. State TS type derives via `typeof AgentStateAnnotation.State`.
+- `addConditionalEdges("grade_context", decisionRouter, { generate_answer: "generate_answer", rewrite_query: "rewrite_query", fallback: "fallback" })`.
+- `recursionLimit` is applied at `.invoke(state, { recursionLimit })`, not at `.compile()`.
+- Fallback if `Annotation` typing rejects the schema under the pinned version: drop down to `new StateGraph<I>({ channels: { ... } })` with the same reducer/default semantics. No architectural change required.
+
+### Acceptance criteria
+
+- `buildAgentGraph(deps)` returns a compiled graph and a default recursion limit.
+- The graph's conditional edge is the only place routing logic lives — no node decides the next node.
+- `analyze_intent` cannot short-circuit to `fallback`; it always flows into `retrieve_context`.
+- `pendingSteps` accumulates across nodes (append reducer); `retrievedChunks` replaces each round (no reducer).
+- A bench-style invocation of `buildAgentGraph({ ...stubs })` followed by `.invoke({...initial}, { recursionLimit })` produces a terminal state with `answer`, `relevanceLabel`, and a non-empty `pendingSteps` array — no DB calls made.
+- Type-check + lint clean for `@portfolio/agent`.
+
+### Verification commands
+
+```
+pnpm --filter @portfolio/agent check-types
+pnpm --filter @portfolio/agent lint
+```
+
+(End-to-end execution against a real DB and real OpenAI is deferred to Phase 4.)
+
+### Must NOT be implemented in this phase
+
+- `runAgent()` public entrypoint.
+- Prisma writes anywhere (no `prisma.agentTrace.create`, no `agentStep.createMany`, no `retrievedContext.createMany`).
+- Smoke script body.
+- LLM grader implementation.
+- Any cross-request memory or session state.
+
+---
+
+## Phase 4 — Persistence, public entrypoint, smoke script & end-to-end verification
+
+### Objective
+
+Close the slice. Add persistence helpers that write `AgentTrace`, `AgentStep`, and `RetrievedContext` rows; build the `runAgent()` public entrypoint that owns the `try / finally` persistence boundary; ship a smoke script that exercises both an answerable and a weak/unanswerable question; verify end-to-end against the local DB.
+
+### Files created or modified
+
+- `packages/agent/src/persistence/trace.ts` *(new)* — four helpers:
+  - `openTrace({ prisma, traceId, request, model })` — `prisma.agentTrace.create` with `id = traceId`, `input = request.message`, `conversationId = request.conversationId ?? null`, `model`, `shouldEscalate: false`. Writing the row up front guarantees a returnable `traceId` even when the graph throws.
+  - `flushSteps({ prisma, traceId, steps })` — `prisma.agentStep.createMany` over `state.pendingSteps`.
+  - `writeRetrievedContexts({ prisma, traceId, chunks })` — `prisma.retrievedContext.createMany` over `acceptedChunks` only (final accepted context, not discarded retrieval rounds). Snapshots `content`, `title`, `score`, `rank`, links `documentChunkId` and `documentId`.
+  - `finalizeTrace({ prisma, traceId, output, confidence, shouldEscalate, retrievedContextCount, latencyMs, retryCount, error? })` — `prisma.agentTrace.update`. Merges `error` (if present) into `metadata`.
+- `packages/agent/src/runAgent.ts` *(new)* — public entrypoint:
+  - `AgentRequestSchema.parse(request)`.
+  - Resolve deps via `resolveDeps(overrides)`.
+  - Mint `traceId` with `crypto.randomUUID()`.
+  - Capture `startedAt = Date.now()`.
+  - `await openTrace({...})` — establishes the durable row up front.
+  - `try { terminalState = await graph.invoke(initialState, { recursionLimit }) }`
+  - `catch (err) { thrown = err }`
+  - `finally { await flushSteps(...); await writeRetrievedContexts(...); await finalizeTrace({ ..., latencyMs: Date.now() - startedAt, error: thrown }); }`
+  - If `thrown`, rethrow.
+  - Else compute `confidenceFor(terminalState)` (first-round good → `high`; good after ≥1 rewrite → `medium`; fallback reached → `low + shouldEscalate=true`).
+  - Return `AgentResponseSchema.parse({ answer, confidence, sources: acceptedChunks, traceId, shouldEscalate, metadata })`.
+- `packages/agent/src/index.ts` *(modified)* — barrel re-exports: `runAgent`, `AgentDeps`, `GraphState`, `StepRecord`, `ChatProvider`, `ContextGrader`, `ContextVerdict`.
+- `packages/agent/scripts/smoke-agent.ts` *(new)* — exercises the agent end-to-end:
+  - Two **independent** `runAgent()` calls. Each gets its own `traceId`. No synthetic conversation threading.
+  - Question 1 (answerable): e.g. `"What is David's technical stack?"`
+  - Question 2 (weak / unanswerable): e.g. `"What is David's favorite database indexing strategy?"`
+  - For each, prints: original question, final answer, confidence, `shouldEscalate`, retry count, whether rewriting happened (and the rewritten query if any — read from the `rewrite_query` step's `metadata.rewrittenQuery`), source previews (rank/score/title/content snippet), and the `traceId`.
+  - Exits non-zero if the answerable question's confidence is `"low"` or if trace persistence throws.
+  - Mirrors the entry/exit pattern from `packages/db/scripts/smoke-retrieval.ts`, including `await prisma.$disconnect()` in `finally`.
+- `packages/agent/package.json` *(modified)* — ensure `smoke:agent` script runs as `tsx --env-file=../../.env scripts/smoke-agent.ts`. Confirm `tsx@^4.22.3` is in `devDependencies`.
+
+### Scope boundaries
+
+- Persistence helpers only touch the three trace-related Prisma models. No writes to `Conversation`, `Message`, `Document`, `DocumentChunk`, or `ChannelEvent`.
+- Trace persistence runs at the entrypoint, not in nodes. Nodes already only append to `state.pendingSteps`.
+- Smoke script consumes the *real* DB (seeded via `pnpm --filter @portfolio/db seed:knowledge`) and the *real* OpenAI provider. There is no mocking layer in MVP.
+
+### Acceptance criteria
+
+- One `AgentTrace` row is written per `runAgent()` call, even when the graph throws mid-run.
+- `AgentStep` rows are written for the meaningful steps actually taken (e.g. answered runs include `intent_classifier`, `retrieve_context`, `grade_context`, `answer_generator`; fallback runs replace `answer_generator` with `fallback_escalation`).
+- `RetrievedContext` rows are written **only** for the final accepted chunks (zero rows for fallback runs).
+- `AgentTrace.latencyMs` reflects the full run including persistence overhead.
+- `AgentResponse` is validated through `AgentResponseSchema` before returning.
+- Confidence assignment follows the rules in `prompt.md` exactly.
+- The smoke script's answerable question returns `confidence ∈ {high, medium}`, `shouldEscalate=false`, ≥1 source.
+- The smoke script's weak question returns `confidence="low"`, `shouldEscalate=true`, `sources=[]`.
+- The smoke script exits non-zero on persistence failure or on a `"low"`-confidence answerable result.
+- `@portfolio/agent` lints and type-checks clean.
+
+### Verification commands
+
+```
+# Type + lint sweep
+pnpm --filter @portfolio/contracts check-types
+pnpm --filter @portfolio/contracts lint
+pnpm --filter @portfolio/agent check-types
+pnpm --filter @portfolio/agent lint
+
+# Ensure infra and corpus are ready
+docker compose up -d
+pnpm --filter @portfolio/db db:migrate
+pnpm --filter @portfolio/db seed:knowledge
+pnpm --filter @portfolio/db smoke:retrieval
+
+# End-to-end agent smoke
+pnpm --filter @portfolio/agent smoke:agent
+```
+
+Manual DB checks (via Prisma Studio or psql):
+
+```sql
+SELECT id, "conversationId", confidence, "shouldEscalate",
+       "retrievedContextCount", "latencyMs", model
+FROM "AgentTrace" ORDER BY "createdAt" DESC LIMIT 2;
+
+SELECT "stepName", status, "latencyMs"
+FROM "AgentStep"
+WHERE "traceId" = (SELECT id FROM "AgentTrace" ORDER BY "createdAt" DESC LIMIT 1)
+ORDER BY "createdAt";
+
+SELECT rank, score, title, LEFT(content, 60)
+FROM "RetrievedContext"
+WHERE "traceId" = (SELECT id FROM "AgentTrace" ORDER BY "createdAt" DESC LIMIT 1)
+ORDER BY rank;
+```
+
+Expected: two recent traces, steps include `intent_classifier` + `retrieve_context` + `grade_context` plus one of `{answer_generator, fallback_escalation}`, and `RetrievedContext` rows present only for the answered question.
+
+### Must NOT be implemented in this phase
+
+- API routes, Fastify wiring, or any consumer of `runAgent()` outside the smoke script.
+- Frontend changes.
+- Twilio handlers.
+- Prisma schema changes / migrations.
+- Evaluation tables, ingestion-job tables.
+- AWS / Kubernetes / deployment scaffolding.
+- Cross-request memory, conversation summarization, or message-row auto-creation.
+- A test runner (vitest/jest). Validation is the smoke script + type-check + lint.
+
+---
+
+## Cross-phase rules
+
+These hold across all four phases and supersede any per-phase ambiguity:
+
+- `decision_router` is a conditional edge, never a node.
+- `persist_trace` is not a node; persistence runs at the entrypoint inside `try / finally`.
+- `analyze_intent` is a pure transform; it cannot short-circuit to `fallback`.
+- Weak-after-retries always routes to `fallback` — no best-effort generate path.
+- Nodes receive dependencies via closure; they never touch `process.env`, never construct clients, never import the `prisma` singleton, never smuggle deps through state.
+- `AgentSourceSchema` is an alias of `RetrievedChunkSchema`, not a parallel definition.
+- `@portfolio/agent` exports TypeScript source directly with no build step, matching `@portfolio/db` and `@portfolio/contracts`.

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -17,7 +17,9 @@
     "smoke:agent": "tsx --env-file=../../.env scripts/smoke-agent.ts"
   },
   "dependencies": {
+    "@langchain/langgraph": "^0.2.74",
     "@portfolio/contracts": "workspace:*",
+    "@portfolio/db": "workspace:*",
     "openai": "^5.0.0",
     "zod": "^3.23.8"
   },

--- a/packages/agent/src/deps.ts
+++ b/packages/agent/src/deps.ts
@@ -1,0 +1,40 @@
+import { prisma, retrieveChunks } from "@portfolio/db";
+import type { PrismaClient } from "@portfolio/db";
+import type { RetrievedChunk } from "@portfolio/contracts/knowledge";
+
+import { createHeuristicGrader } from "@/grader/heuristic";
+import type { ContextGrader } from "@/grader/types";
+import { getChatProvider } from "@/llm/index";
+import type { ChatProvider } from "@/llm/types";
+
+export interface RetrieveInput {
+  query: string;
+  topK?: number;
+}
+
+export type RetrieveFn = (input: RetrieveInput) => Promise<RetrievedChunk[]>;
+
+export interface AgentDeps {
+  prisma: PrismaClient;
+  chatProvider: ChatProvider;
+  grader: ContextGrader;
+  retrieve: RetrieveFn;
+}
+
+export function resolveDeps(overrides: Partial<AgentDeps> = {}): AgentDeps {
+  return {
+    prisma: overrides.prisma ?? prisma,
+    chatProvider: overrides.chatProvider ?? getChatProvider(),
+    grader: overrides.grader ?? createHeuristicGrader(),
+    retrieve:
+      overrides.retrieve ??
+      ((input) =>
+        retrieveChunks({
+          query: input.query,
+          // retrieveChunks expects the post-parse RetrievalQuery shape where
+          // topK is required (Zod fills the default at parse time). Mirror
+          // that default here so the type stays clean.
+          topK: input.topK ?? 5,
+        })),
+  };
+}

--- a/packages/agent/src/graph/index.ts
+++ b/packages/agent/src/graph/index.ts
@@ -1,0 +1,50 @@
+import { END, START, StateGraph } from "@langchain/langgraph";
+
+import type { AgentDeps } from "@/deps";
+
+import { makeAnalyzeIntent } from "./nodes/analyzeIntent";
+import { makeFallback } from "./nodes/fallback";
+import { makeGenerateAnswer } from "./nodes/generateAnswer";
+import { makeGradeContext } from "./nodes/gradeContext";
+import { makeRetrieveContext } from "./nodes/retrieveContext";
+import { makeRewriteQuery } from "./nodes/rewriteQuery";
+import { decisionRouter } from "./routing";
+import { AgentStateAnnotation } from "./state";
+
+export function computeRecursionLimit(maxRetries: number): number {
+  return maxRetries * 4 + 4;
+}
+
+export interface BuiltAgentGraph {
+  graph: ReturnType<ReturnType<typeof buildStateGraph>["compile"]>;
+  defaultRecursionLimit: number;
+}
+
+function buildStateGraph(deps: AgentDeps) {
+  return new StateGraph(AgentStateAnnotation)
+    .addNode("analyze_intent", makeAnalyzeIntent())
+    .addNode("retrieve_context", makeRetrieveContext(deps))
+    .addNode("grade_context", makeGradeContext(deps))
+    .addNode("rewrite_query", makeRewriteQuery(deps))
+    .addNode("generate_answer", makeGenerateAnswer(deps))
+    .addNode("fallback", makeFallback())
+    .addEdge(START, "analyze_intent")
+    .addEdge("analyze_intent", "retrieve_context")
+    .addEdge("retrieve_context", "grade_context")
+    .addConditionalEdges("grade_context", decisionRouter, {
+      generate_answer: "generate_answer",
+      rewrite_query: "rewrite_query",
+      fallback: "fallback",
+    })
+    .addEdge("rewrite_query", "retrieve_context")
+    .addEdge("generate_answer", END)
+    .addEdge("fallback", END);
+}
+
+export function buildAgentGraph(deps: AgentDeps): BuiltAgentGraph {
+  const graph = buildStateGraph(deps).compile();
+  return {
+    graph,
+    defaultRecursionLimit: computeRecursionLimit(1),
+  };
+}

--- a/packages/agent/src/graph/index.ts
+++ b/packages/agent/src/graph/index.ts
@@ -15,11 +15,6 @@ export function computeRecursionLimit(maxRetries: number): number {
   return maxRetries * 4 + 4;
 }
 
-export interface BuiltAgentGraph {
-  graph: ReturnType<ReturnType<typeof buildStateGraph>["compile"]>;
-  defaultRecursionLimit: number;
-}
-
 function buildStateGraph(deps: AgentDeps) {
   return new StateGraph(AgentStateAnnotation)
     .addNode("analyze_intent", makeAnalyzeIntent())
@@ -41,10 +36,12 @@ function buildStateGraph(deps: AgentDeps) {
     .addEdge("fallback", END);
 }
 
-export function buildAgentGraph(deps: AgentDeps): BuiltAgentGraph {
+export function buildAgentGraph(deps: AgentDeps) {
   const graph = buildStateGraph(deps).compile();
   return {
     graph,
     defaultRecursionLimit: computeRecursionLimit(1),
   };
 }
+
+export type BuiltAgentGraph = ReturnType<typeof buildAgentGraph>;

--- a/packages/agent/src/graph/nodes/analyzeIntent.ts
+++ b/packages/agent/src/graph/nodes/analyzeIntent.ts
@@ -1,0 +1,29 @@
+import type { GraphState } from "@/graph/state";
+import { withStep } from "./step";
+
+export function makeAnalyzeIntent() {
+  return async (state: GraphState): Promise<Partial<GraphState>> => {
+    const { result, step } = await withStep("intent_classifier", async () => {
+      const trimmed = state.originalQuery.trim();
+      const isFirstPass =
+        state.currentQuery === "" || state.currentQuery === state.originalQuery;
+      const currentQuery = isFirstPass ? trimmed : state.currentQuery;
+
+      // Deterministic, no-LLM intent capture: short questions usually map to
+      // a single topic, so use the trimmed query itself as the intent hint.
+      const intent =
+        state.intent ?? (trimmed.length > 0 ? trimmed : undefined);
+
+      return {
+        result: { currentQuery, intent },
+        metadata: { isFirstPass },
+      };
+    });
+
+    return {
+      currentQuery: result.currentQuery,
+      intent: result.intent,
+      pendingSteps: [step],
+    };
+  };
+}

--- a/packages/agent/src/graph/nodes/fallback.ts
+++ b/packages/agent/src/graph/nodes/fallback.ts
@@ -1,0 +1,25 @@
+import type { GraphState } from "@/graph/state";
+import { withStep } from "./step";
+
+const FALLBACK_ANSWER =
+  "I don't have enough information in David's portfolio to answer that confidently. I'll flag this so he can follow up directly.";
+
+export function makeFallback() {
+  return async (state: GraphState): Promise<Partial<GraphState>> => {
+    const { result, step } = await withStep("fallback_escalation", async () => {
+      return {
+        result: { answer: FALLBACK_ANSWER, model: "fallback" },
+        metadata: {
+          retryCount: state.retryCount,
+          relevanceLabel: state.relevanceLabel,
+        },
+      };
+    });
+
+    return {
+      answer: result.answer,
+      model: result.model,
+      pendingSteps: [step],
+    };
+  };
+}

--- a/packages/agent/src/graph/nodes/generateAnswer.ts
+++ b/packages/agent/src/graph/nodes/generateAnswer.ts
@@ -1,0 +1,35 @@
+import type { AgentDeps } from "@/deps";
+import type { GraphState } from "@/graph/state";
+import { buildSystemPrompt } from "@/prompts/systemPrompt";
+
+import { withStep } from "./step";
+
+export function makeGenerateAnswer(deps: AgentDeps) {
+  return async (state: GraphState): Promise<Partial<GraphState>> => {
+    const { result, step } = await withStep("answer_generator", async () => {
+      const system = buildSystemPrompt(state.acceptedChunks);
+
+      const chatResult = await deps.chatProvider.chat({
+        messages: [
+          { role: "system", content: system },
+          { role: "user", content: state.originalQuery },
+        ],
+      });
+
+      return {
+        result: { answer: chatResult.content, model: chatResult.model },
+        metadata: {
+          finishReason: chatResult.finishReason,
+          usage: chatResult.usage,
+          acceptedChunkCount: state.acceptedChunks.length,
+        },
+      };
+    });
+
+    return {
+      answer: result.answer,
+      model: result.model,
+      pendingSteps: [step],
+    };
+  };
+}

--- a/packages/agent/src/graph/nodes/gradeContext.ts
+++ b/packages/agent/src/graph/nodes/gradeContext.ts
@@ -1,0 +1,29 @@
+import type { AgentDeps } from "@/deps";
+import type { GraphState } from "@/graph/state";
+
+import { withStep } from "./step";
+
+export function makeGradeContext(deps: AgentDeps) {
+  return async (state: GraphState): Promise<Partial<GraphState>> => {
+    const { result, step } = await withStep("grade_context", async () => {
+      const verdict = await deps.grader.grade(state.retrievedChunks);
+      const accepted = verdict.label === "good" ? verdict.accepted : [];
+      return {
+        result: { verdict, accepted },
+        metadata: {
+          label: verdict.label,
+          reason: verdict.reason,
+          topScore: verdict.topScore,
+          meanScore: verdict.meanScore,
+          acceptedCount: accepted.length,
+        },
+      };
+    });
+
+    return {
+      relevanceLabel: result.verdict.label,
+      acceptedChunks: result.accepted,
+      pendingSteps: [step],
+    };
+  };
+}

--- a/packages/agent/src/graph/nodes/retrieveContext.ts
+++ b/packages/agent/src/graph/nodes/retrieveContext.ts
@@ -1,0 +1,29 @@
+import type { AgentDeps } from "@/deps";
+import type { GraphState } from "@/graph/state";
+
+import { withStep } from "./step";
+
+export function makeRetrieveContext(deps: AgentDeps) {
+  return async (state: GraphState): Promise<Partial<GraphState>> => {
+    const { result, step } = await withStep("retrieve_context", async () => {
+      const chunks = await deps.retrieve({
+        query: state.currentQuery,
+        topK: state.topK,
+      });
+      return {
+        result: chunks,
+        metadata: {
+          query: state.currentQuery,
+          topK: state.topK,
+          count: chunks.length,
+          retryCount: state.retryCount,
+        },
+      };
+    });
+
+    return {
+      retrievedChunks: result,
+      pendingSteps: [step],
+    };
+  };
+}

--- a/packages/agent/src/graph/nodes/rewriteQuery.ts
+++ b/packages/agent/src/graph/nodes/rewriteQuery.ts
@@ -1,0 +1,43 @@
+import type { AgentDeps } from "@/deps";
+import type { GraphState } from "@/graph/state";
+import { buildRewritePrompt } from "@/prompts/rewriteQuery";
+
+import { withStep } from "./step";
+
+export function makeRewriteQuery(deps: AgentDeps) {
+  return async (state: GraphState): Promise<Partial<GraphState>> => {
+    const { result, step } = await withStep("rewrite_query", async () => {
+      const prompt = buildRewritePrompt({
+        originalQuery: state.originalQuery,
+        currentQuery: state.currentQuery,
+        intent: state.intent,
+        weakChunks: state.retrievedChunks,
+      });
+
+      const chatResult = await deps.chatProvider.chat({
+        messages: [
+          { role: "system", content: prompt.system },
+          { role: "user", content: prompt.user },
+        ],
+      });
+
+      const rewritten = chatResult.content.trim();
+
+      return {
+        result: { rewritten },
+        metadata: {
+          previousQuery: state.currentQuery,
+          rewrittenQuery: rewritten,
+          retryCount: state.retryCount + 1,
+          model: chatResult.model,
+        },
+      };
+    });
+
+    return {
+      currentQuery: result.rewritten,
+      retryCount: state.retryCount + 1,
+      pendingSteps: [step],
+    };
+  };
+}

--- a/packages/agent/src/graph/nodes/rewriteQuery.ts
+++ b/packages/agent/src/graph/nodes/rewriteQuery.ts
@@ -21,7 +21,13 @@ export function makeRewriteQuery(deps: AgentDeps) {
         ],
       });
 
-      const rewritten = chatResult.content.trim();
+      // Fall back to the original query when the model returns nothing
+      // usable — a blank string would crash retrieveChunks' NonEmptyString
+      // validation on the next loop. The retry counter still ticks, so the
+      // loop terminates via decisionRouter → fallback within maxRetries.
+      const trimmed = chatResult.content.trim();
+      const rewritten = trimmed.length > 0 ? trimmed : state.originalQuery;
+      const fellBack = trimmed.length === 0;
 
       return {
         result: { rewritten },
@@ -30,6 +36,7 @@ export function makeRewriteQuery(deps: AgentDeps) {
           rewrittenQuery: rewritten,
           retryCount: state.retryCount + 1,
           model: chatResult.model,
+          fellBack,
         },
       };
     });

--- a/packages/agent/src/graph/nodes/step.ts
+++ b/packages/agent/src/graph/nodes/step.ts
@@ -1,0 +1,26 @@
+import type { StepRecord } from "@/graph/state";
+
+export interface StepBody<T> {
+  result: T;
+  metadata?: Record<string, unknown>;
+}
+
+export async function withStep<T>(
+  stepName: string,
+  fn: () => Promise<StepBody<T>>,
+): Promise<{ result: T; step: StepRecord }> {
+  const startedAt = new Date();
+  const { result, metadata } = await fn();
+  const finishedAt = new Date();
+  return {
+    result,
+    step: {
+      stepName,
+      status: "success",
+      startedAt,
+      finishedAt,
+      latencyMs: finishedAt.getTime() - startedAt.getTime(),
+      metadata,
+    },
+  };
+}

--- a/packages/agent/src/graph/routing.ts
+++ b/packages/agent/src/graph/routing.ts
@@ -1,0 +1,9 @@
+import type { GraphState } from "./state";
+
+export type DecisionTarget = "generate_answer" | "rewrite_query" | "fallback";
+
+export function decisionRouter(state: GraphState): DecisionTarget {
+  if (state.relevanceLabel === "good") return "generate_answer";
+  if (state.retryCount < state.maxRetries) return "rewrite_query";
+  return "fallback";
+}

--- a/packages/agent/src/graph/state.ts
+++ b/packages/agent/src/graph/state.ts
@@ -1,0 +1,77 @@
+import { Annotation } from "@langchain/langgraph";
+import type { RetrievedChunk } from "@portfolio/contracts/knowledge";
+
+import type { RelevanceLabel } from "@/grader/types";
+
+export type StepStatus = "success" | "error" | "skipped";
+
+export interface StepRecord {
+  stepName: string;
+  status: StepStatus;
+  startedAt: Date;
+  finishedAt: Date;
+  latencyMs: number;
+  metadata?: Record<string, unknown>;
+  error?: string;
+}
+
+export const AgentStateAnnotation = Annotation.Root({
+  originalQuery: Annotation<string>({
+    reducer: (_prev, next) => next,
+    default: () => "",
+  }),
+  currentQuery: Annotation<string>({
+    reducer: (_prev, next) => next,
+    default: () => "",
+  }),
+  intent: Annotation<string | undefined>({
+    reducer: (_prev, next) => next,
+    default: () => undefined,
+  }),
+  retrievedChunks: Annotation<RetrievedChunk[]>({
+    reducer: (_prev, next) => next,
+    default: () => [],
+  }),
+  acceptedChunks: Annotation<RetrievedChunk[]>({
+    reducer: (_prev, next) => next,
+    default: () => [],
+  }),
+  retryCount: Annotation<number>({
+    reducer: (_prev, next) => next,
+    default: () => 0,
+  }),
+  maxRetries: Annotation<number>({
+    reducer: (_prev, next) => next,
+    default: () => 1,
+  }),
+  relevanceLabel: Annotation<RelevanceLabel | undefined>({
+    reducer: (_prev, next) => next,
+    default: () => undefined,
+  }),
+  answer: Annotation<string | undefined>({
+    reducer: (_prev, next) => next,
+    default: () => undefined,
+  }),
+  model: Annotation<string | undefined>({
+    reducer: (_prev, next) => next,
+    default: () => undefined,
+  }),
+  topK: Annotation<number | undefined>({
+    reducer: (_prev, next) => next,
+    default: () => undefined,
+  }),
+  metadata: Annotation<Record<string, unknown> | undefined>({
+    reducer: (_prev, next) => next,
+    default: () => undefined,
+  }),
+  pendingSteps: Annotation<StepRecord[]>({
+    reducer: (prev, next) => [...prev, ...next],
+    default: () => [],
+  }),
+  traceId: Annotation<string>({
+    reducer: (_prev, next) => next,
+    default: () => "",
+  }),
+});
+
+export type GraphState = typeof AgentStateAnnotation.State;

--- a/packages/db/src/embeddings/openai.ts
+++ b/packages/db/src/embeddings/openai.ts
@@ -1,6 +1,9 @@
 import OpenAI from "openai";
 
-import { getEmbeddingEnv } from "@/env";
+// Relative path (not @/*) so cross-package consumers walking the dependency
+// tree can resolve this — package-local path aliases don't propagate.
+// eslint-disable-next-line no-restricted-imports
+import { getEmbeddingEnv } from "../env";
 import type { EmbeddingProvider } from "./types";
 
 // OpenAI documents a 2048-input cap on embeddings; we chunk requests at this

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -21,3 +21,4 @@ if (process.env.NODE_ENV !== "production") {
 }
 
 export * from "./generated/prisma/client.js";
+export { retrieveChunks, type RetrieveChunksInput } from "./knowledge/retrieve";

--- a/packages/db/src/knowledge/retrieve.ts
+++ b/packages/db/src/knowledge/retrieve.ts
@@ -2,8 +2,12 @@ import pgvector from "pgvector";
 
 import { RetrievalQuerySchema, RetrievedChunkSchema, type RetrievalQuery, type RetrievedChunk } from "@portfolio/contracts/knowledge";
 
-import { getEmbeddingProvider } from "@/embeddings/index";
-import { prisma } from "@/index";
+// Relative paths (not @/*) so cross-package consumers (e.g. @portfolio/agent)
+// resolve these via their own tsc — package-local path aliases don't propagate.
+// eslint-disable-next-line no-restricted-imports
+import { getEmbeddingProvider } from "../embeddings/index";
+// eslint-disable-next-line no-restricted-imports
+import { prisma } from "../index";
 
 export interface RetrieveChunksInput extends RetrievalQuery {
   embedding?: number[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,9 +102,15 @@ importers:
 
   packages/agent:
     dependencies:
+      '@langchain/langgraph':
+        specifier: ^0.2.74
+        version: 0.2.74(@langchain/core@0.3.80(openai@5.23.2(zod@3.25.76)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod-to-json-schema@3.25.2(zod@3.25.76))
       '@portfolio/contracts':
         specifier: workspace:*
         version: link:../contracts
+      '@portfolio/db':
+        specifier: workspace:*
+        version: link:../db
       openai:
         specifier: ^5.0.0
         version: 5.23.2(zod@3.25.76)
@@ -251,6 +257,9 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@cfworker/json-schema@4.1.1':
+    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
   '@electric-sql/pglite-socket@0.1.1':
     resolution: {integrity: sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==}
@@ -640,6 +649,40 @@ packages:
 
   '@kurkle/color@0.3.4':
     resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
+
+  '@langchain/core@0.3.80':
+    resolution: {integrity: sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==}
+    engines: {node: '>=18'}
+
+  '@langchain/langgraph-checkpoint@0.0.18':
+    resolution: {integrity: sha512-IS7zJj36VgY+4pf8ZjsVuUWef7oTwt1y9ylvwu0aLuOn1d0fg05Om9DLm3v2GZ2Df6bhLV1kfWAM0IAl9O5rQQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.2.31 <0.4.0'
+
+  '@langchain/langgraph-sdk@0.0.112':
+    resolution: {integrity: sha512-/9W5HSWCqYgwma6EoOspL4BGYxGxeJP6lIquPSF4FA0JlKopaUv58ucZC3vAgdJyCgg6sorCIV/qg7SGpEcCLw==}
+    peerDependencies:
+      '@langchain/core': '>=0.2.31 <0.4.0'
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+    peerDependenciesMeta:
+      '@langchain/core':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@langchain/langgraph@0.2.74':
+    resolution: {integrity: sha512-oHpEi5sTZTPaeZX1UnzfM2OAJ21QGQrwReTV6+QnX7h8nDCBzhtipAw1cK616S+X8zpcVOjgOtJuaJhXa4mN8w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.2.36 <0.3.0 || >=0.3.40 < 0.4.0'
+      zod-to-json-schema: ^3.x
+    peerDependenciesMeta:
+      zod-to-json-schema:
+        optional: true
 
   '@next/env@16.2.0':
     resolution: {integrity: sha512-OZIbODWWAi0epQRCRjNe1VO45LOFBzgiyqmTLzIqWq6u1wrxKnAyz1HH6tgY/Mc81YzIjRPoYsPAEr4QV4l9TA==}
@@ -1148,11 +1191,17 @@ packages:
   '@types/react@19.2.2':
     resolution: {integrity: sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@typescript-eslint/eslint-plugin@8.50.0':
     resolution: {integrity: sha512-O7QnmOXYKVtPrfYzMolrCTfkezCJS9+ljLdKW/+DCvRsc3UAz+sbH6Xcsv7p30+0OwUbeWfUDAQE0vpabZ3QLg==}
@@ -1235,6 +1284,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1288,6 +1341,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.8:
     resolution: {integrity: sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==}
     engines: {node: '>=6.0.0'}
@@ -1328,6 +1384,10 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
 
   caniuse-lite@1.0.30001761:
     resolution: {integrity: sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g==}
@@ -1382,6 +1442,9 @@ packages:
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
+  console-table-printer@2.15.0:
+    resolution: {integrity: sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1409,6 +1472,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -1596,6 +1663,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -1956,6 +2026,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  js-tiktoken@1.0.21:
+    resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1980,6 +2053,23 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  langsmith@0.3.87:
+    resolution: {integrity: sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==}
+    peerDependencies:
+      '@opentelemetry/api': '*'
+      '@opentelemetry/exporter-trace-otlp-proto': '*'
+      '@opentelemetry/sdk-trace-base': '*'
+      openai: '*'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-proto':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      openai:
+        optional: true
 
   lenis@1.3.23:
     resolution: {integrity: sha512-YxYq3TJqj9sJNv0V9SkyQHejt14xwyIwgDaaMK89Uf9SxQfIszu+gTQSSphh6BWlLTNVKvvXAGkg+Zf+oFIevg==}
@@ -2207,6 +2297,10 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
+
   mysql2@3.15.3:
     resolution: {integrity: sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==}
     engines: {node: '>= 8.0'}
@@ -2300,6 +2394,10 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -2307,6 +2405,18 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -2563,6 +2673,10 @@ packages:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -2644,6 +2758,9 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-wcswidth@1.1.2:
+    resolution: {integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2845,6 +2962,16 @@ packages:
       '@types/react':
         optional: true
 
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
   valibot@1.2.0:
     resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
     peerDependencies:
@@ -2894,6 +3021,11 @@ packages:
   zeptomatch@2.1.0:
     resolution: {integrity: sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -2903,6 +3035,8 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@cfworker/json-schema@4.1.1': {}
 
   '@electric-sql/pglite-socket@0.1.1(@electric-sql/pglite@0.4.1)':
     dependencies:
@@ -3175,6 +3309,55 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@kurkle/color@0.3.4': {}
+
+  '@langchain/core@0.3.80(openai@5.23.2(zod@3.25.76))':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      ansi-styles: 5.2.0
+      camelcase: 6.3.0
+      decamelize: 1.2.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.3.87(openai@5.23.2(zod@3.25.76))
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 10.0.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+
+  '@langchain/langgraph-checkpoint@0.0.18(@langchain/core@0.3.80(openai@5.23.2(zod@3.25.76)))':
+    dependencies:
+      '@langchain/core': 0.3.80(openai@5.23.2(zod@3.25.76))
+      uuid: 10.0.0
+
+  '@langchain/langgraph-sdk@0.0.112(@langchain/core@0.3.80(openai@5.23.2(zod@3.25.76)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 9.0.1
+    optionalDependencies:
+      '@langchain/core': 0.3.80(openai@5.23.2(zod@3.25.76))
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
+  '@langchain/langgraph@0.2.74(@langchain/core@0.3.80(openai@5.23.2(zod@3.25.76)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod-to-json-schema@3.25.2(zod@3.25.76))':
+    dependencies:
+      '@langchain/core': 0.3.80(openai@5.23.2(zod@3.25.76))
+      '@langchain/langgraph-checkpoint': 0.0.18(@langchain/core@0.3.80(openai@5.23.2(zod@3.25.76)))
+      '@langchain/langgraph-sdk': 0.0.112(@langchain/core@0.3.80(openai@5.23.2(zod@3.25.76)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      uuid: 10.0.0
+      zod: 3.25.76
+    optionalDependencies:
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   '@next/env@16.2.0': {}
 
@@ -3629,9 +3812,13 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  '@types/retry@0.12.0': {}
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/uuid@10.0.0': {}
 
   '@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.2))(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.2)':
     dependencies:
@@ -3750,6 +3937,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -3825,6 +4014,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.8: {}
 
   better-result@2.9.2: {}
@@ -3876,6 +4067,8 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase@6.3.0: {}
+
   caniuse-lite@1.0.30001761: {}
 
   ccount@2.0.1: {}
@@ -3917,6 +4110,10 @@ snapshots:
 
   confbox@0.2.4: {}
 
+  console-table-printer@2.15.0:
+    dependencies:
+      simple-wcswidth: 1.1.2
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3946,6 +4143,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decamelize@1.2.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -4250,6 +4449,8 @@ snapshots:
   estree-util-is-identifier-name@3.0.0: {}
 
   esutils@2.0.3: {}
+
+  eventemitter3@4.0.7: {}
 
   exsolve@1.0.8: {}
 
@@ -4610,6 +4811,10 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  js-tiktoken@1.0.21:
+    dependencies:
+      base64-js: 1.5.1
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.0:
@@ -4634,6 +4839,17 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  langsmith@0.3.87(openai@5.23.2(zod@3.25.76)):
+    dependencies:
+      '@types/uuid': 10.0.0
+      chalk: 4.1.2
+      console-table-printer: 2.15.0
+      p-queue: 6.6.2
+      semver: 7.7.3
+      uuid: 10.0.0
+    optionalDependencies:
+      openai: 5.23.2(zod@3.25.76)
 
   lenis@1.3.23(react@19.2.0):
     optionalDependencies:
@@ -4960,6 +5176,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mustache@4.2.0: {}
+
   mysql2@3.15.3:
     dependencies:
       aws-ssl-profiles: 1.1.2
@@ -5063,6 +5281,8 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  p-finally@1.0.0: {}
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -5070,6 +5290,20 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
 
   parent-module@1.0.1:
     dependencies:
@@ -5338,6 +5572,8 @@ snapshots:
 
   retry@0.12.0: {}
 
+  retry@0.13.1: {}
+
   reusify@1.1.0: {}
 
   run-parallel@1.2.0:
@@ -5464,6 +5700,8 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  simple-wcswidth@1.1.2: {}
 
   source-map-js@1.2.1: {}
 
@@ -5703,6 +5941,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
 
+  uuid@10.0.0: {}
+
+  uuid@9.0.1: {}
+
   valibot@1.2.0(typescript@5.9.2):
     optionalDependencies:
       typescript: 5.9.2
@@ -5772,6 +6014,10 @@ snapshots:
     dependencies:
       grammex: 3.1.12
       graphmatch: 1.1.1
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary

Phase 3 of `docs/03-build-agent-core-plan.md`. Wires the cyclic CRAG-style LangGraph that ties together the Phase 2 building blocks (chat provider, heuristic grader, prompt builders) into a real retrieve → grade → (answer | rewrite-and-retry | fallback) loop.

- `packages/agent/src/deps.ts` — `AgentDeps` + `resolveDeps()` DI seam. Pulls `prisma`, `retrieveChunks`, `getChatProvider()`, `createHeuristicGrader()` by default; every dep is overrideable.
- `packages/agent/src/graph/state.ts` — `Annotation.Root` state with an explicit append reducer on `pendingSteps`; `retrievedChunks` / `acceptedChunks` / `retryCount` use replace semantics. Exports `GraphState`, `StepRecord`, `StepStatus`.
- `packages/agent/src/graph/routing.ts` — `decisionRouter` conditional edge. Weak-after-retries always routes to `fallback` — no best-effort generate path.
- `packages/agent/src/graph/nodes/` — six DI closures: `analyzeIntent`, `retrieveContext`, `gradeContext`, `rewriteQuery`, `generateAnswer`, `fallback`, plus a small `withStep` timing helper. Each node emits a `StepRecord` into `pendingSteps`; none touch `@portfolio/db`, `getChatProvider`, `process.env`, or `crypto` — verified by grep.
- `packages/agent/src/graph/index.ts` — `buildAgentGraph(deps) → { graph, defaultRecursionLimit }`; exports `computeRecursionLimit(maxRetries)` for Phase 4 to use per-request.

### Out-of-doc touches (necessary plumbing)

- `packages/db/src/index.ts` — re-export `retrieveChunks` + its input type so `deps.ts` reaches it through the package's `.` export (db only declares `.` in `exports`).
- `packages/db/src/{knowledge/retrieve.ts, embeddings/openai.ts}` — converted three `@/*` imports to relative paths so cross-package consumers (the agent's tsc) can resolve them. Package-local path aliases don't propagate through cross-package walks. Added per-line `eslint-disable-next-line no-restricted-imports` with a one-line "why".

### Explicitly NOT in this PR (Phase 4)

- `runAgent()` public entrypoint
- Persistence helpers (`AgentTrace` / `AgentStep` / `RetrievedContext` writes)
- Smoke script body
- Barrel re-exports from `packages/agent/src/index.ts`

## Test plan

- [x] `pnpm --filter @portfolio/contracts check-types` — clean
- [x] `pnpm --filter @portfolio/contracts lint` — clean
- [x] `pnpm --filter @portfolio/db check-types` — clean (requires `pnpm --filter @portfolio/db db:generate` once with `DATABASE_URL` set)
- [x] `pnpm --filter @portfolio/db lint` — clean
- [x] `pnpm --filter @portfolio/agent check-types` — clean
- [x] `pnpm --filter @portfolio/agent lint` — clean
- [x] DI guardrail: `grep -rnE "@portfolio/db|getChatProvider|createOpenAIChatProvider|process\.env|from \"crypto\"" packages/agent/src/graph/nodes/` returns zero hits
- [ ] End-to-end smoke is intentionally deferred to Phase 4 (no `runAgent`, no persistence wired yet)