### PR TITLE
Add runAgent entrypoint, trace persistence, and smoke for @portfolio/agent (Phase 4)

### DIFF
--- a/packages/agent/scripts/smoke-agent.ts
+++ b/packages/agent/scripts/smoke-agent.ts
@@ -1,0 +1,109 @@
+import { prisma } from "@portfolio/db";
+import type { AgentResponse } from "@portfolio/contracts/agent";
+
+import { runAgent } from "@/runAgent";
+
+interface SmokeCase {
+  label: string;
+  question: string;
+  expectAnswerable: boolean;
+}
+
+const CASES: SmokeCase[] = [
+  {
+    label: "answerable",
+    question: "What is David's technical stack?",
+    expectAnswerable: true,
+  },
+  {
+    label: "unanswerable",
+    question: "What is David's favorite database indexing strategy?",
+    expectAnswerable: false,
+  },
+];
+
+async function readRewrites(traceId: string): Promise<string[]> {
+  const rows = await prisma.agentStep.findMany({
+    where: { traceId, stepName: "rewrite_query" },
+    orderBy: { createdAt: "asc" },
+    select: { metadata: true },
+  });
+
+  return rows
+    .map((row) => {
+      const metadata = row.metadata as Record<string, unknown> | null;
+      const rewritten = metadata?.rewrittenQuery;
+      return typeof rewritten === "string" ? rewritten : null;
+    })
+    .filter((value): value is string => value !== null);
+}
+
+function printResult(
+  label: string,
+  question: string,
+  response: AgentResponse,
+  rewrites: string[],
+): void {
+  console.log(`\n[smoke-agent] === ${label} ===`);
+  console.log(`[smoke-agent] question:      ${question}`);
+  console.log(`[smoke-agent] answer:        ${response.answer}`);
+  console.log(`[smoke-agent] confidence:    ${response.confidence}`);
+  console.log(`[smoke-agent] shouldEscalate: ${response.shouldEscalate}`);
+  console.log(`[smoke-agent] traceId:       ${response.traceId}`);
+
+  const retryCount = response.metadata?.retryCount;
+  console.log(`[smoke-agent] retryCount:    ${retryCount ?? 0}`);
+  console.log(`[smoke-agent] model:         ${response.metadata?.model ?? "—"}`);
+
+  if (rewrites.length > 0) {
+    console.log(`[smoke-agent] rewrites:      ${rewrites.length}`);
+    rewrites.forEach((rewritten, i) => {
+      console.log(`[smoke-agent]   #${i + 1}: ${rewritten}`);
+    });
+  } else {
+    console.log(`[smoke-agent] rewrites:      none`);
+  }
+
+  if (response.sources.length === 0) {
+    console.log(`[smoke-agent] sources:       []`);
+  } else {
+    console.log(`[smoke-agent] sources:`);
+    for (const source of response.sources) {
+      const snippet = source.content.replace(/\s+/g, " ").slice(0, 120);
+      const ellipsis = source.content.length > 120 ? "…" : "";
+      console.log(
+        `[smoke-agent]   #${source.rank} score=${source.score.toFixed(4)} title=${source.title ?? "—"} :: ${snippet}${ellipsis}`,
+      );
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  for (const testCase of CASES) {
+    console.log(`\n[smoke-agent] running case: ${testCase.label}`);
+
+    const response = await runAgent({
+      message: testCase.question,
+      channel: "web",
+    });
+
+    const rewrites = await readRewrites(response.traceId);
+    printResult(testCase.label, testCase.question, response, rewrites);
+
+    if (testCase.expectAnswerable && response.confidence === "low") {
+      console.error(
+        `[smoke-agent] FAIL: expected answerable case "${testCase.label}" to return high/medium confidence, got "low"`,
+      );
+      process.exitCode = 1;
+    }
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error("[smoke-agent] failed:", err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/packages/agent/scripts/smoke-agent.ts
+++ b/packages/agent/scripts/smoke-agent.ts
@@ -22,6 +22,14 @@ const CASES: SmokeCase[] = [
   },
 ];
 
+function pickRewritten(metadata: unknown): string | null {
+  if (metadata === null || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return null;
+  }
+  const rewritten = (metadata as Record<string, unknown>).rewrittenQuery;
+  return typeof rewritten === "string" ? rewritten : null;
+}
+
 async function readRewrites(traceId: string): Promise<string[]> {
   const rows = await prisma.agentStep.findMany({
     where: { traceId, stepName: "rewrite_query" },
@@ -30,11 +38,7 @@ async function readRewrites(traceId: string): Promise<string[]> {
   });
 
   return rows
-    .map((row) => {
-      const metadata = row.metadata as Record<string, unknown> | null;
-      const rewritten = metadata?.rewrittenQuery;
-      return typeof rewritten === "string" ? rewritten : null;
-    })
+    .map((row) => pickRewritten(row.metadata))
     .filter((value): value is string => value !== null);
 }
 
@@ -79,13 +83,22 @@ function printResult(
 }
 
 async function main(): Promise<void> {
+  let hadFailure = false;
+
   for (const testCase of CASES) {
     console.log(`\n[smoke-agent] running case: ${testCase.label}`);
 
-    const response = await runAgent({
-      message: testCase.question,
-      channel: "web",
-    });
+    let response: AgentResponse;
+    try {
+      response = await runAgent({
+        message: testCase.question,
+        channel: "web",
+      });
+    } catch (err) {
+      console.error(`[smoke-agent] FAIL: case "${testCase.label}" threw:`, err);
+      hadFailure = true;
+      continue;
+    }
 
     const rewrites = await readRewrites(response.traceId);
     printResult(testCase.label, testCase.question, response, rewrites);
@@ -94,8 +107,18 @@ async function main(): Promise<void> {
       console.error(
         `[smoke-agent] FAIL: expected answerable case "${testCase.label}" to return high/medium confidence, got "low"`,
       );
-      process.exitCode = 1;
+      hadFailure = true;
     }
+    if (!testCase.expectAnswerable && response.confidence !== "low") {
+      console.error(
+        `[smoke-agent] FAIL: expected unanswerable case "${testCase.label}" to return "low" confidence, got "${response.confidence}"`,
+      );
+      hadFailure = true;
+    }
+  }
+
+  if (hadFailure) {
+    process.exitCode = 1;
   }
 }
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,1 +1,9 @@
-export {};
+export { runAgent } from "./runAgent";
+export type { AgentDeps, RetrieveFn, RetrieveInput } from "./deps";
+export type { GraphState, StepRecord, StepStatus } from "./graph/state";
+export type { ChatProvider, ChatMessage, ChatResult } from "./llm/types";
+export type {
+  ContextGrader,
+  ContextVerdict,
+  RelevanceLabel,
+} from "./grader/types";

--- a/packages/agent/src/persistence/trace.ts
+++ b/packages/agent/src/persistence/trace.ts
@@ -1,0 +1,148 @@
+import { Prisma, type PrismaClient } from "@portfolio/db";
+import type { AgentRequest } from "@portfolio/contracts/agent";
+import type { RetrievedChunk } from "@portfolio/contracts/knowledge";
+
+import type { StepRecord, StepStatus } from "@/graph/state";
+
+export interface OpenTraceInput {
+  prisma: PrismaClient;
+  traceId: string;
+  request: AgentRequest;
+  model?: string | null;
+}
+
+export async function openTrace({
+  prisma,
+  traceId,
+  request,
+  model = null,
+}: OpenTraceInput): Promise<void> {
+  await prisma.agentTrace.create({
+    data: {
+      id: traceId,
+      input: request.message,
+      conversationId: request.conversationId ?? null,
+      model: model ?? null,
+      shouldEscalate: false,
+    },
+  });
+}
+
+export interface FlushStepsInput {
+  prisma: PrismaClient;
+  traceId: string;
+  steps: StepRecord[];
+}
+
+const STEP_STATUS_TO_DB: Record<StepStatus, string> = {
+  success: "completed",
+  error: "failed",
+  skipped: "skipped",
+};
+
+export async function flushSteps({
+  prisma,
+  traceId,
+  steps,
+}: FlushStepsInput): Promise<void> {
+  if (steps.length === 0) return;
+
+  await prisma.agentStep.createMany({
+    data: steps.map((step) => ({
+      traceId,
+      stepName: step.stepName,
+      status: STEP_STATUS_TO_DB[step.status],
+      latencyMs: step.latencyMs,
+      metadata: toJsonInput(step.metadata),
+      createdAt: step.startedAt,
+    })),
+  });
+}
+
+export interface WriteRetrievedContextsInput {
+  prisma: PrismaClient;
+  traceId: string;
+  chunks: RetrievedChunk[];
+}
+
+export async function writeRetrievedContexts({
+  prisma,
+  traceId,
+  chunks,
+}: WriteRetrievedContextsInput): Promise<void> {
+  if (chunks.length === 0) return;
+
+  await prisma.retrievedContext.createMany({
+    data: chunks.map((chunk) => ({
+      traceId,
+      documentChunkId: chunk.chunkId,
+      documentId: chunk.documentId,
+      title: chunk.title,
+      content: chunk.content,
+      score: chunk.score,
+      rank: chunk.rank,
+    })),
+  });
+}
+
+export interface FinalizeTraceInput {
+  prisma: PrismaClient;
+  traceId: string;
+  output: string | null;
+  confidence: string | null;
+  shouldEscalate: boolean;
+  retrievedContextCount: number;
+  latencyMs: number;
+  model: string | null;
+  retryCount: number;
+  error?: unknown;
+}
+
+export async function finalizeTrace({
+  prisma,
+  traceId,
+  output,
+  confidence,
+  shouldEscalate,
+  retrievedContextCount,
+  latencyMs,
+  model,
+  retryCount,
+  error,
+}: FinalizeTraceInput): Promise<void> {
+  const metadata: Record<string, unknown> = { retryCount };
+  if (error !== undefined) {
+    metadata.error = serializeError(error);
+  }
+
+  await prisma.agentTrace.update({
+    where: { id: traceId },
+    data: {
+      output,
+      confidence,
+      shouldEscalate,
+      retrievedContextCount,
+      latencyMs,
+      model,
+      metadata: metadata as Prisma.InputJsonValue,
+    },
+  });
+}
+
+function toJsonInput(
+  value: Record<string, unknown> | undefined,
+): Prisma.InputJsonValue | undefined {
+  if (value === undefined) return undefined;
+  return value as Prisma.InputJsonValue;
+}
+
+function serializeError(err: unknown): Record<string, unknown> {
+  if (err instanceof Error) {
+    return {
+      name: err.name,
+      message: err.message,
+      ...(err.stack ? { stack: err.stack } : {}),
+    };
+  }
+  return { value: String(err) };
+}

--- a/packages/agent/src/persistence/trace.ts
+++ b/packages/agent/src/persistence/trace.ts
@@ -22,7 +22,7 @@ export async function openTrace({
       id: traceId,
       input: request.message,
       conversationId: request.conversationId ?? null,
-      model: model ?? null,
+      model,
       shouldEscalate: false,
     },
   });

--- a/packages/agent/src/runAgent.ts
+++ b/packages/agent/src/runAgent.ts
@@ -1,0 +1,120 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  AgentRequestSchema,
+  AgentResponseSchema,
+  type AgentConfidence,
+  type AgentResponse,
+} from "@portfolio/contracts/agent";
+
+import { resolveDeps, type AgentDeps } from "@/deps";
+import { buildAgentGraph, computeRecursionLimit } from "@/graph/index";
+import type { GraphState } from "@/graph/state";
+import {
+  finalizeTrace,
+  flushSteps,
+  openTrace,
+  writeRetrievedContexts,
+} from "@/persistence/trace";
+
+export async function runAgent(
+  rawRequest: unknown,
+  overrides: Partial<AgentDeps> = {},
+): Promise<AgentResponse> {
+  const request = AgentRequestSchema.parse(rawRequest);
+  const deps = resolveDeps(overrides);
+
+  const traceId = randomUUID();
+  const startedAt = Date.now();
+  const maxRetries = request.maxRetries ?? 1;
+
+  await openTrace({
+    prisma: deps.prisma,
+    traceId,
+    request,
+    model: null,
+  });
+
+  const { graph } = buildAgentGraph(deps);
+  const recursionLimit = computeRecursionLimit(maxRetries);
+
+  let terminalState: GraphState | undefined;
+  let thrown: unknown;
+
+  try {
+    terminalState = await graph.invoke(
+      {
+        originalQuery: request.message,
+        currentQuery: request.message,
+        maxRetries,
+        topK: request.topK,
+        metadata: request.metadata,
+        traceId,
+      },
+      { recursionLimit },
+    );
+  } catch (err) {
+    thrown = err;
+  } finally {
+    await flushSteps({
+      prisma: deps.prisma,
+      traceId,
+      steps: terminalState?.pendingSteps ?? [],
+    });
+    await writeRetrievedContexts({
+      prisma: deps.prisma,
+      traceId,
+      chunks: terminalState?.acceptedChunks ?? [],
+    });
+    await finalizeTrace({
+      prisma: deps.prisma,
+      traceId,
+      output: terminalState?.answer ?? null,
+      confidence: confidenceFor(terminalState),
+      shouldEscalate: shouldEscalateFor(terminalState, thrown),
+      retrievedContextCount: terminalState?.acceptedChunks.length ?? 0,
+      latencyMs: Date.now() - startedAt,
+      model: terminalState?.model ?? null,
+      retryCount: terminalState?.retryCount ?? 0,
+      error: thrown,
+    });
+  }
+
+  if (thrown !== undefined) {
+    throw thrown;
+  }
+
+  const state = terminalState as GraphState;
+  if (!state.answer) {
+    throw new Error("Agent graph terminated without an answer");
+  }
+
+  return AgentResponseSchema.parse({
+    answer: state.answer,
+    confidence: confidenceFor(state),
+    sources: state.acceptedChunks,
+    traceId,
+    shouldEscalate: shouldEscalateFor(state, undefined),
+    metadata: {
+      retryCount: state.retryCount,
+      ...(state.model ? { model: state.model } : {}),
+    },
+  });
+}
+
+function confidenceFor(state: GraphState | undefined): AgentConfidence {
+  if (!state) return "low";
+  const lastStep = state.pendingSteps[state.pendingSteps.length - 1];
+  if (lastStep?.stepName === "fallback_escalation") return "low";
+  if (state.relevanceLabel !== "good") return "low";
+  if (state.retryCount === 0) return "high";
+  return "medium";
+}
+
+function shouldEscalateFor(
+  state: GraphState | undefined,
+  thrown: unknown,
+): boolean {
+  if (thrown !== undefined) return true;
+  return confidenceFor(state) === "low";
+}

--- a/packages/agent/src/runAgent.ts
+++ b/packages/agent/src/runAgent.ts
@@ -55,7 +55,12 @@ export async function runAgent(
     );
   } catch (err) {
     thrown = err;
-  } finally {
+  }
+
+  // Persistence runs unconditionally but outside `finally` so a failure here
+  // doesn't silently replace the graph error when both fail.
+  let persistenceError: unknown;
+  try {
     await flushSteps({
       prisma: deps.prisma,
       traceId,
@@ -78,10 +83,21 @@ export async function runAgent(
       retryCount: terminalState?.retryCount ?? 0,
       error: thrown,
     });
+  } catch (err) {
+    persistenceError = err;
   }
 
   if (thrown !== undefined) {
+    if (persistenceError !== undefined) {
+      console.error(
+        `[runAgent] trace ${traceId} persistence failed while handling a graph error:`,
+        persistenceError,
+      );
+    }
     throw thrown;
+  }
+  if (persistenceError !== undefined) {
+    throw persistenceError;
   }
 
   const state = terminalState as GraphState;


### PR DESCRIPTION
## Summary

- Closes Phase 4 of the agent core: persistence helpers (`AgentTrace` / `AgentStep` / `RetrievedContext`), the `runAgent()` public entrypoint that owns the `try / finally` persistence boundary, and an end-to-end smoke script.
- Trace is opened **up front** so every call returns a durable `traceId` even when the graph throws; steps, retrieved contexts, and final fields are written in `finally`.
- Confidence assignment follows `prompt.md` exactly: first-round `"good"` → `high`, `"good"` after ≥1 rewrite → `medium`, fallback or graph throw → `low` + `shouldEscalate=true`.

## Changes

- `packages/agent/src/persistence/trace.ts` — `openTrace` / `flushSteps` / `writeRetrievedContexts` / `finalizeTrace`. Maps `StepRecord.status` (`success|error|skipped`) → `AgentStep.status` (`completed|failed|skipped`) at the boundary, keeping nodes unchanged.
- `packages/agent/src/runAgent.ts` — parses `AgentRequestSchema`, mints `traceId` via `crypto.randomUUID()`, calls `buildAgentGraph(deps).graph.invoke(...)` with the Phase 3 recursion limit, persists in `finally`, rethrows after persistence, validates the response through `AgentResponseSchema`.
- `packages/agent/src/index.ts` — public barrel: `runAgent` + types (`AgentDeps`, `GraphState`, `StepRecord`, `ChatProvider`, `ContextGrader`, etc.).
- `packages/agent/scripts/smoke-agent.ts` — two independent `runAgent()` calls (answerable + unanswerable), prints per-trace details with rewritten queries read back from `AgentStep` via Prisma, exits non-zero if the answerable case returns `"low"`.

## Verification performed

- `pnpm --filter @portfolio/contracts check-types` ✓
- `pnpm --filter @portfolio/contracts lint` ✓
- `pnpm --filter @portfolio/agent check-types` ✓
- `pnpm --filter @portfolio/agent lint` ✓
- `pnpm --filter @portfolio/agent smoke:agent` — ran end-to-end against local Postgres + OpenAI; both runs produced one `AgentTrace` row each with full step trails, `RetrievedContext` correctly empty on fallback runs, `latencyMs` and `model` populated on finalize. The smoke exits non-zero today because the Phase 2 heuristic grader's default thresholds are above the current corpus's score distribution — every question lands in `fallback`. That is **out of scope for this PR** (Phase 2 + corpus follow-up).

## Test plan

- [ ] `cp .env.example .env` and set `OPENAI_API_KEY`
- [ ] `docker compose up -d`
- [ ] `pnpm --filter @portfolio/db db:migrate && pnpm --filter @portfolio/db seed:knowledge`
- [ ] `pnpm --filter @portfolio/contracts check-types && pnpm --filter @portfolio/contracts lint`
- [ ] `pnpm --filter @portfolio/agent check-types && pnpm --filter @portfolio/agent lint`
- [ ] `pnpm --filter @portfolio/agent smoke:agent` — confirm two traces persist with expected step names; `RetrievedContext` rows present only for runs that reached `answer_generator`.
- [ ] Spot-check via psql / Prisma Studio:
  ```sql
  SELECT id, confidence, "shouldEscalate", "retrievedContextCount", "latencyMs", model
  FROM "AgentTrace" ORDER BY "createdAt" DESC LIMIT 2;
  ```

## Known follow-ups (not in this PR)

- Replace the heuristic `ContextGrader` (`packages/agent/src/grader/heuristic.ts`) with an LLM-based grader using the same interface — the seam was built for this in Phase 2.
- Expand the knowledge corpus so recruiter-facing questions ("stack", "experience", "projects") produce strong enough retrieval scores for any grader to confidently accept.

## Out of scope (per the Phase 4 plan)

API routes, frontend, Twilio handlers, Prisma schema / migrations, evaluation tables, ingestion-job tables, infra-as-code, cross-request memory, conversation/message auto-creation, test framework introduction. No Phase 3 node code was touched.