### PR TITLE
Document agent core in architecture + workspace-tree

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,3 +47,97 @@ This preserves a clean separation:
 model that matches the `ChannelEvent` contract — persistence and contracts
 share the same vocabulary, and Twilio (or any other provider) lives only in
 edge-adapter code, not in the core schema.
+
+## Agent core
+
+`packages/agent` turns the retrieval layer in `packages/db` into a grounded,
+self-correcting assistant. It is built as a cyclic LangGraph workflow in the
+spirit of **CRAG** (Corrective RAG): retrieve → grade → either answer, rewrite
+and retry, or escalate.
+
+### Workflow shape
+
+The graph has six nodes and one conditional edge:
+
+```
+analyze_intent → retrieve_context → grade_context ──(decisionRouter)──┐
+                       ▲                                              ├─► generate_answer ─► END
+                       │                                              ├─► rewrite_query ─► (loop back to retrieve_context)
+                       │                                              └─► fallback        ─► END
+                       └──────────────── rewrite_query ───────────────┘
+```
+
+- **`analyze_intent`** — pure transform; normalizes the query on first pass and
+  captures a light intent hint. Cannot short-circuit.
+- **`retrieve_context`** — calls `deps.retrieve()` (which wraps
+  `retrieveChunks()` from `@portfolio/db`) and **replaces** the retrieved set
+  each round; prior rounds are not merged.
+- **`grade_context`** — runs the injected `ContextGrader`, labels the result
+  `"good" | "weak" | "none"`, and on `"good"` populates `acceptedChunks`.
+- **`decisionRouter`** (a conditional edge, not a node) — `good` → answer;
+  otherwise if retries remain → rewrite; else → fallback. Weak-after-retries
+  always escalates rather than best-effort answering.
+- **`rewrite_query`** — LLM-rewrites the query, increments `retryCount`, loops
+  back to retrieval.
+- **`generate_answer`** — LLM answer grounded strictly on `acceptedChunks`.
+- **`fallback`** — deterministic escalation string (no LLM call, so it survives
+  provider outages).
+
+### Dependency injection
+
+Nodes never read `process.env`, construct clients, or import the `prisma`
+singleton. They receive everything through closures over `AgentDeps`:
+
+```
+interface AgentDeps {
+  prisma: PrismaClient;
+  chatProvider: ChatProvider;   // see packages/agent/src/llm
+  grader: ContextGrader;        // see packages/agent/src/grader
+  retrieve: RetrieveFn;         // thin wrapper over retrieveChunks()
+}
+```
+
+`resolveDeps(overrides)` produces production defaults (real OpenAI provider,
+heuristic grader, real Prisma + retrieval) but accepts overrides so the graph
+is testable with fakes without any monkey-patching.
+
+### Public entrypoint and persistence boundary
+
+`runAgent(request)` is the only public surface intended for callers outside
+the package. It:
+
+1. Validates the request via `AgentRequestSchema`
+   (`packages/contracts/src/agent.ts`).
+2. Mints a `traceId` and opens an `AgentTrace` row **up front** so a durable
+   id is always returnable — even when the graph throws mid-run.
+3. Invokes the compiled graph.
+4. Persists `AgentStep` rows (one per executed node) and `RetrievedContext`
+   rows (snapshots of the **final accepted** chunks only — zero rows for
+   fallback runs) and finalizes the `AgentTrace`.
+5. Returns an `AgentResponse` validated through `AgentResponseSchema`, with
+   confidence assigned by terminal state: `good` on first pass → `high`,
+   `good` after rewrite → `medium`, fallback or thrown graph → `low` +
+   `shouldEscalate: true`.
+
+Persistence runs **only** at this entrypoint boundary; nodes accumulate
+`StepRecord` entries in graph state and the entrypoint flushes them. This
+keeps the graph pure and testable, and makes the trace contract a single
+file to audit (`packages/agent/src/persistence/trace.ts`).
+
+### Wire contracts
+
+`AgentRequestSchema` and `AgentResponseSchema` in
+`packages/contracts/src/agent.ts` are the seams the future API and frontend
+will consume. `AgentSourceSchema` is an alias of `RetrievedChunkSchema` from
+`./knowledge` — there is no parallel chunk shape.
+
+### Known limitations (planned follow-ups)
+
+- The current `ContextGrader` is a score-threshold heuristic. The interface
+  was deliberately built so an LLM-based grader can be slotted in without
+  graph changes; that swap is the next planned change.
+- The seeded knowledge corpus is thin for several recruiter-facing topics
+  (stack details, recent projects, role history). Today many otherwise-
+  answerable questions fall into `fallback` because retrieval scores are
+  below any reasonable grader threshold. Corpus expansion is tracked
+  alongside the grader upgrade.

--- a/docs/workspace-tree.md
+++ b/docs/workspace-tree.md
@@ -11,12 +11,10 @@ Portfolio/
 ├── .gitignore                  — top-level ignore rules.
 ├── .npmrc                      — pnpm settings (hoisting, registry).
 ├── docker-compose.yml          — spins up local Postgres + pgvector for dev.
-├── KNOWLEDGE_PIPELINE_EXPLAINED.md — this document.
 ├── package.json                — root workspace manifest; defines repo-wide scripts and dev deps.
 ├── pnpm-lock.yaml              — pinned dep graph.
 ├── pnpm-workspace.yaml         — declares which folders are workspace packages.
 ├── turbo.json                  — Turborepo pipeline config (build/test/lint task graph).
-├── prompt-build-knowledge-ingestion-and-retrieval.md — original spec/prompt this branch implements.
 │
 ├── apps/
 │   └── web/                    — Next.js 16 portfolio site (React 19 + Tailwind v4).
@@ -70,7 +68,11 @@ Portfolio/
 │           └── mergeProps.ts   — utility to merge JSX prop objects.
 │
 ├── docs/
-│   └── architecture.md         — high-level architecture write-up for the AI assistant.
+│   ├── 03-build-agent-core-plan.md   — phased implementation plan that produced packages/agent.
+│   ├── architecture.md               — high-level architecture write-up (channel model + agent core).
+│   ├── knowledge-pipeline.md         — walkthrough of the @portfolio/db knowledge ingestion + retrieval path.
+│   ├── module-resolution-refactor.md — record of the Bundler-resolution / drop-`.js`-suffix migration.
+│   └── workspace-tree.md             — this document.
 │
 ├── infra/
 │   └── postgres/
@@ -127,6 +129,49 @@ Portfolio/
     │           ├── internal/{class,prismaNamespace,prismaNamespaceBrowser}.ts
     │           └── models/{AgentStep, AgentTrace, ChannelEvent, Conversation, Document, DocumentChunk, Message, RetrievedContext}.ts
     │
+    ├── agent/                  — LangGraph CRAG agent: turns retrieveChunks() into a grounded, self-correcting assistant.
+    │   ├── eslint.config.js
+    │   ├── package.json        — exports @portfolio/agent; defines smoke:agent script + LangGraph/OpenAI runtime deps.
+    │   ├── tsconfig.json
+    │   │
+    │   ├── scripts/
+    │   │   └── smoke-agent.ts  — exercises runAgent() end-to-end against the real DB + OpenAI with an answerable + an unanswerable question.
+    │   │
+    │   └── src/
+    │       ├── index.ts        — barrel: runAgent + public types (AgentDeps, GraphState, ChatProvider, ContextGrader, …).
+    │       ├── env.ts          — lazy, Zod-validated chat env accessor (OPENAI_API_KEY, CHAT_MODEL, CHAT_TIMEOUT_MS, CHAT_MAX_TOKENS).
+    │       ├── deps.ts         — AgentDeps shape + resolveDeps(): the DI seam for prisma, chatProvider, grader, retrieve.
+    │       ├── runAgent.ts     — public entrypoint; owns trace persistence at the try/catch boundary.
+    │       │
+    │       ├── graph/
+    │       │   ├── index.ts    — buildAgentGraph(deps): wires the StateGraph + computeRecursionLimit().
+    │       │   ├── state.ts    — AgentStateAnnotation: state channels (originalQuery, retrievedChunks, pendingSteps, …) + StepRecord type.
+    │       │   ├── routing.ts  — decisionRouter: conditional edge from grade_context → generate / rewrite / fallback.
+    │       │   └── nodes/
+    │       │       ├── step.ts            — withStep() helper: wraps a node body and emits a StepRecord.
+    │       │       ├── analyzeIntent.ts   — first-pass intent capture + query normalization (pure; never short-circuits).
+    │       │       ├── retrieveContext.ts — calls deps.retrieve(); replaces retrievedChunks each round.
+    │       │       ├── gradeContext.ts    — runs deps.grader; sets relevanceLabel + acceptedChunks.
+    │       │       ├── rewriteQuery.ts    — LLM-rewrites the query on weak retrieval; increments retryCount.
+    │       │       ├── generateAnswer.ts  — LLM answer grounded on acceptedChunks (terminal).
+    │       │       └── fallback.ts        — deterministic escalation string; no LLM call (terminal).
+    │       │
+    │       ├── llm/
+    │       │   ├── types.ts    — ChatProvider interface + ChatMessage / ChatRequest / ChatResult types.
+    │       │   ├── openai.ts   — createOpenAIChatProvider(): lazy OpenAI client w/ timeout + retries, AbortSignal-aware.
+    │       │   └── index.ts    — getChatProvider() memoized singleton.
+    │       │
+    │       ├── grader/
+    │       │   ├── types.ts     — ContextGrader interface, ContextVerdict, RelevanceLabel ("good" | "weak" | "none").
+    │       │   └── heuristic.ts — createHeuristicGrader(): score-threshold grader (LLM grader is a planned follow-up).
+    │       │
+    │       ├── prompts/
+    │       │   ├── systemPrompt.ts — buildSystemPrompt(acceptedChunks): grounded-answer system prompt.
+    │       │   └── rewriteQuery.ts — buildRewritePrompt({…}): query-rewrite system + user prompts.
+    │       │
+    │       └── persistence/
+    │           └── trace.ts    — openTrace / flushSteps / writeRetrievedContexts / finalizeTrace; runs at the entrypoint, never in nodes.
+    │
     ├── portfolio-content/      — single source of truth for portfolio copy (used by web + seeder).
     │   ├── package.json
     │   ├── tsconfig.json
@@ -156,6 +201,7 @@ Portfolio/
 ## How to read the tree quickly
 
 - **★ marks the knowledge pipeline.** Trace it top-to-bottom: `seed-knowledge-data.ts` → `seed-knowledge.ts` → (`chunking.ts` + `documents.ts` + `embeddings/openai.ts` + `chunks.ts`) → at query time, `retrieve.ts` → smoke-checked by `smoke-retrieval.ts`. The schemas they all speak through live in `packages/contracts/src/knowledge.ts`.
+- **`packages/agent/`** sits on top of the knowledge pipeline. Trace it from the entrypoint: `runAgent` (`src/runAgent.ts`) → graph (`src/graph/index.ts` + nodes) → `deps.retrieve` (wraps `retrieveChunks()`) and `deps.chatProvider` (OpenAI) → trace persistence (`src/persistence/trace.ts`). The high-level shape lives in `docs/architecture.md` under "Agent core"; smoke-checked by `scripts/smoke-agent.ts`.
 - **`apps/web/`** is the public-facing Next.js site. It renders `@portfolio/content` directly; the knowledge pipeline reads that same package so the bot stays in sync with the site.
 - **`packages/db/src/generated/prisma/`** is auto-generated — never edit by hand; it gets blown away by `prisma generate`.
 - **Shared configs** (`eslint-config`, `typescript-config`) keep all packages on the same lint/TS settings without duplication.


### PR DESCRIPTION
## Summary

Now that `@portfolio/agent` is merged (#10 → #13), update the two architecture-level docs so they reflect the as-merged state instead of pre-implementation placeholders.

- `docs/architecture.md` — adds an **Agent core** section: CRAG workflow shape (six nodes + conditional router), `AgentDeps` DI seam, `runAgent` as the single persistence boundary, the `AgentRequest` / `AgentResponse` wire contracts, and the heuristic-grader + thin-corpus limitations called out explicitly so future readers don't mistake them for bugs.
- `docs/workspace-tree.md` — adds the full `packages/agent/` subtree annotated at the same depth as `packages/db/`, plus an agent-trail bullet under "How to read the tree quickly". While in the file, fixed three obvious stale items: dropped the long-gone `KNOWLEDGE_PIPELINE_EXPLAINED.md` root entry (the doc lives at `docs/knowledge-pipeline.md` since #9), dropped the dropped `prompt-build-knowledge-ingestion-and-retrieval.md` root entry, and expanded the `docs/` listing from one entry to all five current docs.

## Test plan

- [ ] Render `docs/architecture.md` on GitHub — the new "Agent core" section reads cleanly with the ASCII workflow diagram intact.
- [ ] Render `docs/workspace-tree.md` on GitHub — the agent subtree is correctly indented inside the `packages/` block and the docs/ listing matches `ls docs/` on `main`.
- [ ] Spot-check the agent subtree against the actual filesystem (`find packages/agent -type f`) — every file should appear once and only once.

## Out of scope

No code changes. No changes to other docs (`docs/knowledge-pipeline.md`, `docs/module-resolution-refactor.md`, `docs/03-build-agent-core-plan.md`) or to `apps/web/` entries in the tree.