### PR TITLE
Add /api/chat proxy + agent client + slash registries (Phase A)

### DIFF
--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -4,3 +4,12 @@
 MAIL_USERNAME=
 MAIL_PASSWORD=
 TARGET_EMAIL=
+
+# URL where apps/api is reachable; consumed only by the /api/chat proxy route
+# (server-side; do NOT prefix with NEXT_PUBLIC_).
+AGENT_API_URL=http://127.0.0.1:3001
+
+# E.164 WhatsApp number surfaced by the David Agent widget (header button,
+# persistent WhatsApp line, /whatsapp slash command). NEXT_PUBLIC_ so it is
+# inlined into the client bundle. Falls back to a placeholder if unset.
+NEXT_PUBLIC_PORTFOLIO_WHATSAPP_NUMBER=+15551234567

--- a/apps/web/app/about/page.tsx
+++ b/apps/web/app/about/page.tsx
@@ -95,7 +95,7 @@ export default function AboutMePage() {
             ))}
           </div>
         </Section>
-        <Section className="block text-center">
+        <Section id="projects" className="block text-center">
           <h3 className="mb-12 text-2xl font-medium">— I&apos;m proud of —</h3>
           <div className="mx-auto grid w-full max-w-5xl grid-cols-1 gap-12 md:grid-cols-6">
             {projects.map(

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1,0 +1,45 @@
+// Same-origin proxy to apps/api's /chat endpoint.
+// Intentionally dumb: no auth, no transformation, no business logic.
+// Keeps the browser same-origin (no CORS) and hides the Fastify origin from clients.
+
+export async function POST(request: Request) {
+  const upstream = process.env.AGENT_API_URL;
+  if (!upstream) {
+    console.error(
+      '[api/chat] AGENT_API_URL is not set; refusing to forward request',
+    );
+    return Response.json(
+      {
+        code: 'internal_error',
+        message: 'Agent API is not configured on the server.',
+      },
+      { status: 500 },
+    );
+  }
+
+  const body = await request.text();
+
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(`${upstream}/chat`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+    });
+  } catch (error) {
+    console.error('[api/chat] upstream fetch failed', error);
+    return Response.json(
+      {
+        code: 'internal_error',
+        message: 'Failed to reach the agent service.',
+      },
+      { status: 502 },
+    );
+  }
+
+  const responseBody = await upstreamResponse.text();
+  return new Response(responseBody, {
+    status: upstreamResponse.status,
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -2,6 +2,10 @@
 // Intentionally dumb: no auth, no transformation, no business logic.
 // Keeps the browser same-origin (no CORS) and hides the Fastify origin from clients.
 
+// Upstream timeout: long enough to cover model-call latency on apps/api,
+// short enough that a hung agent doesn't tie up a Next.js worker indefinitely.
+const UPSTREAM_TIMEOUT_MS = 30_000;
+
 export async function POST(request: Request) {
   const upstream = process.env.AGENT_API_URL;
   if (!upstream) {
@@ -25,15 +29,23 @@ export async function POST(request: Request) {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body,
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
     });
   } catch (error) {
-    console.error('[api/chat] upstream fetch failed', error);
+    const isTimeout =
+      error instanceof DOMException && error.name === 'TimeoutError';
+    console.error(
+      `[api/chat] upstream fetch ${isTimeout ? 'timed out' : 'failed'}`,
+      error,
+    );
     return Response.json(
       {
         code: 'internal_error',
-        message: 'Failed to reach the agent service.',
+        message: isTimeout
+          ? 'Agent service did not respond in time.'
+          : 'Failed to reach the agent service.',
       },
-      { status: 502 },
+      { status: isTimeout ? 504 : 502 },
     );
   }
 

--- a/apps/web/components/common/Section/Section.tsx
+++ b/apps/web/components/common/Section/Section.tsx
@@ -3,9 +3,11 @@ import { twMerge } from 'tailwind-merge';
 export function Section({
   children,
   className,
-}: React.HTMLAttributes<HTMLDivElement>) {
+  ...rest
+}: React.HTMLAttributes<HTMLElement>) {
   return (
     <section
+      {...rest}
       className={twMerge(
         ['flex', 'w-full', 'flex-wrap', 'justify-evenly', 'gap-12', 'pb-24'],
         className,

--- a/apps/web/model/slashCommands.ts
+++ b/apps/web/model/slashCommands.ts
@@ -1,0 +1,64 @@
+import { contact } from '@portfolio/content';
+
+export type SlashCommand =
+  | {
+      command: string;
+      label: string;
+      description: string;
+      kind: 'prompt';
+      prompt: string;
+    }
+  | {
+      command: string;
+      label: string;
+      description: string;
+      kind: 'navigate';
+      href: string;
+    }
+  | {
+      command: string;
+      label: string;
+      description: string;
+      kind: 'external';
+      href: string;
+    };
+
+// UI-only affordance. Never sent to the API in any form (not even metadata).
+// `command` is the unique key — no separate id field.
+export const slashCommands: readonly SlashCommand[] = [
+  {
+    command: '/projects',
+    label: 'Projects',
+    description: "Browse what I'm proud of",
+    kind: 'navigate',
+    href: '/about#projects',
+  },
+  {
+    command: '/stack',
+    label: 'Stack',
+    description: 'My tech stack & tools',
+    kind: 'prompt',
+    prompt: "What is David's technical stack?",
+  },
+  {
+    command: '/leadership',
+    label: 'Leadership',
+    description: '3+ years leading Front-End teams',
+    kind: 'prompt',
+    prompt: "Tell me about David's leadership experience.",
+  },
+  {
+    command: '/contact',
+    label: 'Contact',
+    description: 'Email, LinkedIn, GitHub',
+    kind: 'navigate',
+    href: '/contact',
+  },
+  {
+    command: '/whatsapp',
+    label: 'WhatsApp',
+    description: 'Continue this chat on WhatsApp',
+    kind: 'external',
+    href: `https://wa.me/${contact.whatsappNumber.replace(/^\+/, '')}`,
+  },
+];

--- a/apps/web/model/suggestedPrompts.ts
+++ b/apps/web/model/suggestedPrompts.ts
@@ -1,0 +1,15 @@
+export interface SuggestedPrompt {
+  label: string;
+  // Optional reference to a slashCommands[].command. When set, clicking the chip
+  // dispatches via the slash command path; when undefined, the label is sent as
+  // plain user text.
+  commandRef?: string;
+}
+
+export const suggestedPrompts: readonly SuggestedPrompt[] = [
+  { label: "What's David's technical stack?", commandRef: '/stack' },
+  { label: "Show me David's projects", commandRef: '/projects' },
+  { label: 'What kind of engineer is David?' },
+  { label: 'Tell me about his leadership', commandRef: '/leadership' },
+  { label: 'How can I contact David?', commandRef: '/contact' },
+];

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@portfolio/content": "workspace:*",
+    "@portfolio/contracts": "workspace:*",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-visually-hidden": "^1.1.0",
     "clsx": "^2.1.1",

--- a/apps/web/utils/agentClient.ts
+++ b/apps/web/utils/agentClient.ts
@@ -1,10 +1,12 @@
 import {
+  ChatResponseSchema,
+  ErrorResponseSchema,
+} from '@portfolio/contracts';
+import type {
   ChatRequest,
   ChatResponse,
-  ChatResponseSchema,
   ErrorCode,
   ErrorResponse,
-  ErrorResponseSchema,
 } from '@portfolio/contracts';
 
 export class AgentClientError extends Error {

--- a/apps/web/utils/agentClient.ts
+++ b/apps/web/utils/agentClient.ts
@@ -1,0 +1,81 @@
+import {
+  ChatRequest,
+  ChatResponse,
+  ChatResponseSchema,
+  ErrorCode,
+  ErrorResponse,
+  ErrorResponseSchema,
+} from '@portfolio/contracts';
+
+export class AgentClientError extends Error {
+  readonly code: ErrorCode;
+  readonly details?: unknown;
+
+  constructor(response: ErrorResponse, options?: { cause?: unknown }) {
+    super(response.message, options);
+    this.name = 'AgentClientError';
+    this.code = response.code;
+    this.details = response.details;
+  }
+}
+
+// Single seam for all agent network access — UI components must not call fetch directly.
+export async function sendAgentMessage(
+  input: ChatRequest,
+): Promise<ChatResponse> {
+  let response: Response;
+  try {
+    response = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+  } catch (cause) {
+    throw new AgentClientError(
+      {
+        code: 'internal_error',
+        message: 'Failed to reach the agent service.',
+      },
+      { cause },
+    );
+  }
+
+  let rawBody: unknown;
+  try {
+    rawBody = await response.json();
+  } catch (cause) {
+    throw new AgentClientError(
+      {
+        code: 'internal_error',
+        message: 'Agent service returned a non-JSON response.',
+      },
+      { cause },
+    );
+  }
+
+  if (!response.ok) {
+    const parsed = ErrorResponseSchema.safeParse(rawBody);
+    if (parsed.success) {
+      throw new AgentClientError(parsed.data);
+    }
+    throw new AgentClientError(
+      {
+        code: 'internal_error',
+        message: `Agent service returned an unrecognised error (HTTP ${response.status}).`,
+      },
+      { cause: parsed.error },
+    );
+  }
+
+  const parsed = ChatResponseSchema.safeParse(rawBody);
+  if (!parsed.success) {
+    throw new AgentClientError(
+      {
+        code: 'internal_error',
+        message: 'Agent service returned an unrecognised response shape.',
+      },
+      { cause: parsed.error },
+    );
+  }
+  return parsed.data;
+}

--- a/docs/05-connect-web-chat-ui.prompt.md
+++ b/docs/05-connect-web-chat-ui.prompt.md
@@ -1,0 +1,255 @@
+Implement the production-ready frontend version of the floating AI assistant widget based on the approved Claude Design output.
+
+Goal:
+Turn the approved “Ask David / David Agent” design into a real, reusable, maintainable portfolio feature connected to the existing API layer.
+
+Context:
+This is a portfolio-integrated AI assistant. It should appear globally across the site as a floating chat widget, not as a separate page. The backend (`apps/api`) and shared wire contracts (`@portfolio/contracts`) already exist; the widget must consume them rather than invent parallel shapes or mock responses.
+
+Scope:
+Frontend implementation and API client integration only.
+
+Do not implement LangGraph.
+Do not modify database code.
+Do not modify Prisma schema.
+Do not modify `@portfolio/agent` or `apps/api` unless a missing field in `@portfolio/contracts` is genuinely blocking. If that happens, stop and surface it before changing the contract.
+Additive edits to `@portfolio/content` are allowed (e.g. adding a WhatsApp number to `contact.ts` for the `/whatsapp` slash command). Do not restructure or rename existing exports.
+Do not implement Twilio.
+Do not add Kubernetes/AWS/deployment code.
+Do not introduce unnecessary dependencies.
+Do not replace the existing design system.
+
+Use the approved design:
+
+- The approved design currently lives only at the Claude Design URL referenced when this prompt was created; there are no local design files in the repo yet. Open the rendered `index.html` from that URL and translate it into real components — do not invent a different visual direction.
+- Preserve the visual direction as much as possible (layout, spacing, typography choices, motion language, color treatment).
+- Refactor only where needed for production-quality component structure, state handling, accessibility, API integration, and future extensibility.
+- Any deviation from the design must be deliberate and called out in the post-implementation summary.
+
+Feature naming:
+
+- Floating entry point: “Ask David”
+- Expanded assistant name: “David Agent”
+
+Primary behavior:
+
+- The widget is available globally across the portfolio. Mount it once in `apps/web/app/layout.tsx` so it persists across route changes; do not remount per page.
+- Because the widget is mounted in the root layout, its local React state (messages, conversationId, open/closed) survives client-side navigation for free. Do not introduce React Context, Zustand, Redux, or any cross-tree state container for this widget.
+- The collapsed launcher appears near the bottom-right.
+- On desktop, it opens into a polished floating chat panel/card.
+- On mobile, it opens into a comfortable mobile chat surface, such as a bottom sheet, drawer, or modal-like panel.
+- Users can type a message, send it, see loading state, receive a real response from the API, and continue the conversation.
+- Silkscreen *is* used inside the widget — for the trigger label ("ASK DAVID") and the header name ("DAVID AGENT"). This is a deliberate retro display accent and not limited to the hero.
+
+WhatsApp has three converging surfaces (not just a slash command):
+
+- A header icon button (always visible inside the panel).
+- A persistent line between the scroll region and the composer, visible across every state (empty, conversation, typing, error, mobile). Copy adapts: "Continue there" when the conversation is empty, "Continue this chat there" once there are messages.
+- The `/whatsapp` slash command.
+
+All three open the same `wa.me` deep link, built from `contact.whatsappNumber` in `@portfolio/content` — define the href once and reuse it; do not duplicate URL construction across surfaces. `/twilio` is dropped entirely from the slash command registry.
+
+Global `/` keyboard shortcut:
+
+- Pressing `/` anywhere on the site (when no `INPUT`/`TEXTAREA` is focused) opens the widget. The trigger pill displays a `/` kbd hint badge that advertises this shortcut. Escape closes the widget (Radix Dialog handles this for free).
+
+API integration:
+
+Transport — use a same-origin Next.js Route Handler as a thin proxy, not a direct cross-origin call:
+
+- Add `apps/web/app/api/chat/route.ts` that forwards `POST` bodies to `${AGENT_API_URL}/chat` and returns the upstream response. The route handler is intentionally dumb: no auth, no transformation, no business logic. This mirrors the existing `apps/web/app/api/contact/route.ts` pattern, keeps the browser same-origin (no CORS to configure), and hides the Fastify origin from clients. The response is JSON, not streaming — do not introduce SSE/`text/event-stream` plumbing in the proxy.
+- The browser-side client always calls `/api/chat` (relative). It never reads `AGENT_API_URL` and there must be no `NEXT_PUBLIC_AGENT_API_URL`.
+- Add `AGENT_API_URL` to `apps/web/.env.local.example` with a comment explaining it points at `apps/api` (default `http://127.0.0.1:3001` in local dev).
+
+Contracts — use the shared wire schemas, do not redeclare them:
+
+- The request body must be `ChatRequest` from `@portfolio/contracts` (`packages/contracts/src/chat.ts`). The success response must be parsed as `ChatResponse`. Error responses must be parsed as `ErrorResponse` from `@portfolio/contracts/src/errors.ts`.
+- `channel` is always `"web"` from this client. You may rely on the schema default rather than passing it explicitly, but be consistent.
+- If the UI needs view-model shapes (e.g. a `ChatMessage` with `id`, `role`, `status`, `createdAt`), define them separately in the web app. Do not leak `ChatResponse`/`AgentSource` directly into render props — normalize at the client boundary.
+
+Client shape:
+
+- Expose a single function (or small hook) such as `sendAgentMessage(input): Promise<ChatResponse>` — synchronous request/response only. The current API is JSON, not streaming; do not preemptively design around `AsyncIterable`, `ReadableStream`, SSE, or WebSocket. Streaming will be a future, deliberate change to both the API and this boundary.
+- The client owns: serializing the `ChatRequest`, calling `/api/chat`, parsing the body, validating it against `ChatResponseSchema` (or `ErrorResponseSchema` on non-2xx), and surfacing errors as typed values rather than thrown strings.
+- UI components must never call `fetch` directly. All network access for the assistant goes through this one boundary.
+
+Error handling:
+
+- Branch on `ErrorResponse.code` — the closed set is `validation_error | conversation_not_found | agent_failure | internal_error`. At minimum: on `conversation_not_found`, drop the stale `conversationId` and let the next send start a fresh conversation; on `validation_error`, surface a “message couldn’t be sent” state without retrying; on `agent_failure` / `internal_error`, surface a retryable error state.
+- Do not silently swallow errors. Do not show raw error JSON. Do not block the user from typing a new message after an error.
+
+Do not hardcode assistant responses in the UI.
+
+Conversation behavior:
+
+- Maintain local chat state in the widget — plain React state in the widget component, not a global store.
+- `conversationId` is **in-memory only**. It persists across client-side route changes (because the widget is layout-mounted) but resets on full page refresh or new tab. Do not write it to `localStorage`, `sessionStorage`, cookies, or URL params.
+- If the API returns a `conversationId`, store it and include it in every subsequent `sendAgentMessage` call until the conversation is reset (by a `conversation_not_found` error, or by a refresh). This slice does not include a user-facing "Start new conversation" affordance — do not add one.
+- Append user messages immediately (optimistic).
+- Show assistant loading/typing state while awaiting the API response.
+- Append assistant response on success.
+- Show graceful error state on failure, with a retry affordance if practical.
+- Avoid duplicate sends while a message is in flight.
+- Render each assistant message as its own bubble. Do not bake assumptions about its text being immutable post-render (a future streaming change should be able to swap the bubble's text source), but do not introduce any streaming machinery — no `AsyncIterable`, no `ReadableStream` parsing, no incremental-text state.
+
+Slash command palette (client-side only):
+
+The widget exposes a `/` command palette purely as a UI affordance. These are **not** agent capabilities — the agent must remain unaware they exist. Treat them like Slack / Discord / Notion slash commands or a VS Code command palette: shortcuts that the client interprets and dispatches, not tools the LLM picks.
+
+Hard rules:
+
+- Do not extend `@portfolio/contracts` for slash commands. Do not add a `skill`, `command`, or equivalent field anywhere on the wire.
+- Do not include a slash-command id in `ChatRequest.metadata`, not even "just for analytics." Once it's on the wire the contract owns it, and the agent will eventually start branching on it.
+- A `kind: 'prompt'` command simply seeds a normal user message and sends it through the unchanged `/chat` flow. From the API's perspective it is indistinguishable from the user typing the same text by hand.
+- The registry is **data, not a component**, so it lives under `apps/web/model/` (e.g. `apps/web/model/slashCommands.ts`), matching the existing convention set by `apps/web/model/ContactFormData.ts`. It is never promoted to `@portfolio/contracts` or any shared package — these are UI affordances, not domain concepts.
+
+Shape — discriminated union by `kind`:
+
+```ts
+type SlashCommand =
+  | { command: string; label: string; description: string; kind: 'prompt';   prompt: string }
+  | { command: string; label: string; description: string; kind: 'navigate'; href: string }
+  | { command: string; label: string; description: string; kind: 'external'; href: string };
+```
+
+- `command` is the literal string the user types (e.g. `"/stack"`). It IS the unique key — there is no separate `id` field. Must start with `/`.
+- `kind: 'prompt'` — `prompt` is the canned text seeded into the composer and sent through the normal chat flow.
+- `kind: 'navigate'` — `href` is an internal route, opened via Next.js `Link` / `router.push`.
+- `kind: 'external'` — `href` is an absolute URL opened in a new tab with `rel="noopener noreferrer"`.
+
+Content sources — URLs and contact details (WhatsApp number, resume path, contact email, internal section anchors) must come from `@portfolio/content`. Do not hardcode them in the registry; the content package is the single source of truth.
+
+Initial set (five entries — `/twilio` is dropped):
+
+- `/projects` — `kind: 'navigate'`, href `"/about#projects"`.
+- `/stack` — `kind: 'prompt'`, prompt: `"What is David's technical stack?"`.
+- `/leadership` — `kind: 'prompt'`, prompt: `"Tell me about David's leadership experience."`.
+- `/contact` — `kind: 'navigate'`, href: `"/contact"`.
+- `/whatsapp` — `kind: 'external'`, href: WhatsApp deep link (`https://wa.me/<number>`) built from `contact.whatsappNumber` in `@portfolio/content`. The content package owns the number; do not inline it in the registry. The same href is reused by the header WhatsApp button and the persistent WhatsApp line — see the "WhatsApp has three converging surfaces" subsection above.
+
+Behavior:
+
+- Typing `/` opens a filtered list of matching commands from the registry. Filter by substring on `command` and `label`.
+- Selecting a command:
+  - `kind: 'prompt'`: send immediately as a normal chat message (so the shortcut feels like a click-to-ask). The composer may briefly show the seeded text, then submit.
+  - `kind: 'navigate'`: close the panel and push the route.
+  - `kind: 'external'`: open the URL in a new tab. Leave the panel open so the user can come back.
+- Unknown slash commands (e.g. user types `/asdf` and hits enter) are sent to the agent as plain text — the agent already handles arbitrary input. Do not show an error, do not "graceful fallback" with a UI message; just send the text.
+- Suggested-prompt chips in the welcome/empty state render from a separate `suggestedPrompts` list (`apps/web/model/suggestedPrompts.ts`) whose entries are `{ label; commandRef? }`. Chips with a `commandRef` dispatch through the slash command path (so `/stack`, `/projects`, etc. behave identically whether triggered from a chip or the slash popover); chips without a `commandRef` send the `label` as plain user text. The list is not required to be 1:1 with the slash registry.
+
+Component expectations:
+Use the existing repo conventions. Choose names that fit the current component structure (`apps/web/components/common/*`).
+
+Prefer a clean decomposition such as:
+
+- FloatingAIChat / DavidAgentWidget
+- ChatLauncher
+- ChatPanel
+- ChatHeader
+- ChatMessageList
+- ChatMessageBubble
+- ChatComposer
+- SuggestedPrompts
+- CommandSuggestions
+- slash command registry (UI-only; see the "Slash command palette" section above)
+- agent chat API client / hook
+
+Do not over-split if the repo conventions suggest a simpler structure, but keep the code readable and extensible.
+
+UI states:
+The widget should support:
+
+- collapsed state
+- expanded state
+- welcome/empty state
+- user message
+- assistant message
+- loading/typing state
+- API error/fallback state
+- slash command suggestions
+- mobile open state
+
+Accessibility:
+
+- Keyboard-accessible open/close behavior.
+- Proper labels for icon-only buttons (`aria-label` on the launcher, close button, send button, etc.).
+- Focus management when opening the chat (move focus into the panel; restore focus to the launcher on close).
+- Escape key closes the widget if appropriate.
+- The message list must be an `aria-live="polite"` region so screen readers announce new assistant messages without interrupting the user.
+- Loading/typing state must be announced to assistive tech (e.g. `aria-busy` on the message list, or a visually-hidden status node), not just shown visually.
+- Composer is usable with keyboard.
+- Enter sends message.
+- Shift+Enter creates a newline if multiline input is used.
+- Comfortable touch targets on mobile.
+- Visible focus states.
+
+Mobile requirements:
+
+- The collapsed entry point should remain reachable near bottom-right.
+- Expanded chat should use an appropriate amount of viewport height.
+- Composer should remain usable on mobile.
+- Avoid horizontal overflow.
+- Avoid covering critical navigation awkwardly.
+- The experience should feel intentionally designed for mobile, not just resized desktop UI.
+
+Styling:
+
+- Use the existing design system, primitives, tokens, typography, spacing, colors, borders, shadows, and motion patterns.
+- Preserve the approved Claude Design direction.
+- Avoid generic SaaS chatbot aesthetics.
+- Avoid making it feel like a third-party plugin.
+- Do not install a heavy UI library. Existing deps already cover everything needed: Radix Dialog (panel/sheet primitive), framer-motion (motion), react-feather (icons), react-markdown (assistant message rendering), tailwind-merge / tailwindcss (styling).
+
+Future integration readiness:
+The client boundary should be easy to *replace* later, not pre-built for futures. Keep the public surface of the client (`sendAgentMessage`) narrow enough that swapping its internals later is a contained change. Do not add the following speculatively:
+
+- streaming responses (no `AsyncIterable`, `ReadableStream`, SSE, or WebSocket wiring),
+- persisted conversations beyond the in-memory `conversationId`,
+- additional slash-command `kind`s beyond `prompt | navigate | external`,
+- Twilio handoff (the `/whatsapp` shortcut is a simple deep link, not an inbound-message bridge),
+- source display UI,
+- trace/debug metadata panels.
+
+Each of those will be a deliberate future change; building scaffolding for them now is out of scope.
+
+Quality requirements:
+
+- Strict TypeScript.
+- Avoid `any`.
+- Prefer existing contracts and schemas where available — specifically `ChatRequestSchema`, `ChatResponseSchema`, and `ErrorResponseSchema` from `@portfolio/contracts`.
+- Keep API request/response normalization explicit at the client boundary.
+- Keep components reusable.
+- Keep error handling visible and simple.
+- Do not silently fail.
+- Do not create unrelated refactors.
+- Do not duplicate slash command definitions across components — the registry is the single source.
+- Keep the implementation easy to review.
+
+Acceptance criteria:
+
+- The floating widget appears globally across the portfolio, mounted in `apps/web/app/layout.tsx`.
+- The collapsed launcher works.
+- The expanded chat works on desktop.
+- The expanded chat works well on mobile.
+- The empty-state suggested-prompt chips render from a `suggestedPrompts` list which may reference slash commands by `commandRef` but is not required to be 1:1 with the slash registry. Chips with a `commandRef` dispatch through the same code path as the slash popover.
+- The slash command registry lives under `apps/web/` only; no changes to `@portfolio/contracts`, no shortcut id on the wire, no entry in `ChatRequest.metadata`.
+- Sending a message calls the real existing API via the `apps/web/app/api/chat/route.ts` proxy, which forwards to `${AGENT_API_URL}/chat`.
+- Wire shapes match `ChatRequestSchema` / `ChatResponseSchema` / `ErrorResponseSchema` from `@portfolio/contracts` — verified by TypeScript and by runtime parsing at the client boundary.
+- API loading state is visible and announced to assistive tech.
+- API success response renders as an assistant message.
+- API error response renders a graceful fallback/error UI, with branching on `ErrorResponse.code` (at minimum: `conversation_not_found` clears the stored `conversationId`).
+- `conversationId` is preserved in-memory across messages and route changes, and reset on page refresh — never written to storage.
+- `kind: 'navigate'` and `kind: 'external'` shortcuts dispatch client-side (route push / new-tab open) and do not call `/chat`.
+- Existing portfolio pages remain visually intact.
+- `pnpm lint` and `pnpm check-types` (or the repo’s equivalent) pass with no new warnings.
+
+After implementation:
+
+1. Show the files created or modified.
+2. Explain where the widget was mounted globally (and confirm it is mounted exactly once).
+3. Explain the component structure.
+4. Explain the slash command registry — its location under `apps/web/`, its `SlashCommand` discriminated union, and confirm no part of it is shared with `@portfolio/contracts` or sent to the API.
+5. Explain how slash commands and welcome-state suggested-prompt chips both consume the same registry, and how each `kind` is dispatched (`prompt` → normal chat send, `navigate` → router push, `external` → new tab).
+6. Explain how the frontend calls the real API, including the proxy route and `AGENT_API_URL` env var.
+7. Explain how `conversationId`, loading, success, and error states are handled (including which `ErrorResponse.code`s are branched on).
+8. Mention any design compromises made from the approved design, if any.

--- a/docs/06-connect-web-chat-ui.plan.md
+++ b/docs/06-connect-web-chat-ui.plan.md
@@ -1,0 +1,400 @@
+# Plan — Connect web chat UI to the agent API
+
+## Context
+
+`apps/api` (Fastify) and `@portfolio/contracts` (`ChatRequestSchema` / `ChatResponseSchema` / `ErrorResponseSchema`) are already shipped and smoke-tested. `apps/web` (Next.js 16, React 19, Tailwind v4) has no AI surface yet. The goal is a globally-mounted floating "Ask David / David Agent" widget that calls the existing API, plus a UI-only slash command palette and two dedicated WhatsApp handoff surfaces.
+
+The Claude Design bundle was extracted from the URL referenced in `docs/05-connect-web-chat-ui.prompt.md` — full design fidelity is now known (trigger pill, 380×580 card with sky→fuchsia hairline gradient, header with BETA pill, persistent WhatsApp line, etc.). The implementer should refer back to `/tmp/design-extract/floating-ai-chat-card/project/chat-widget.jsx` for the source of truth on motion, dimensions, and copy.
+
+Why multi-phase: boundary plumbing, visual fidelity, and a11y/mobile polish have different risk profiles. Splitting lets the visual direction be reviewed and adjusted on its own diff before mobile rework piles on.
+
+## Decisions locked during planning (override `docs/05-connect-web-chat-ui.prompt.md` where they conflict)
+
+These overrides emerged from reading the design and resolving conflicts with the prompt's prior decisions. **Phase A includes updating `docs/05-connect-web-chat-ui.prompt.md` to reflect them.**
+
+- **WhatsApp has three converging surfaces, not just a slash command.** A header icon button (always visible), a persistent line *between the scroll region and the composer* (visible across every state — empty, conversation, typing, error, mobile), and a `/whatsapp` slash command. All three open the same `wa.me` deep link. The persistent line's copy adapts: "Continue there" when empty, "Continue this chat there" when there are messages.
+- **`/twilio` is dropped entirely** from the slash command registry. The "Why Twilio?" suggested-prompt chip remains as a plain text question (no command ref).
+- **Suggested prompts are a separate list, not derived 1:1 from the slash registry.** New file: `apps/web/model/suggestedPrompts.ts` with `{ label; commandRef?: string }`. Chips with a `commandRef` dispatch via the slash command path; chips without dispatch send the label as plain text. This relaxes the prompt's "no parallel hardcoded lists" rule.
+- **Global `/` keyboard shortcut is in scope (Phase B).** Pressing `/` anywhere on the site (when no input/textarea is focused) opens the widget. The trigger pill displays a `/` kbd hint badge that this shortcut advertises. Escape closes (Radix Dialog handles this).
+- **Silkscreen is used inside the widget** — for the trigger label ("ASK DAVID") and the header name ("DAVID AGENT"). The prompt previously said "do not introduce Silkscreen — it's hero-only"; that's wrong, the design uses it deliberately for the retro display flavor.
+- **SlashCommand shape includes a `description` (= design's `hint`)** but **no `id` field** — `command` IS the unique key. The design's `tag` field is not load-bearing; omit it.
+
+## Other locked decisions (carried over from `docs/05`, unchanged)
+
+- **Transport:** same-origin Next.js Route Handler at `apps/web/app/api/chat/route.ts` proxying to `${AGENT_API_URL}/chat`. Server-only env var; no `NEXT_PUBLIC_*`; no CORS.
+- **Wire contracts:** `ChatRequest` / `ChatResponse` / `ErrorResponse` imported from `@portfolio/contracts`. No contract churn.
+- **Conversation:** `conversationId` is in-memory only. No localStorage / sessionStorage / cookie. No user-facing "new conversation" affordance.
+- **State:** plain React state inside the widget; widget is mounted once in `apps/web/app/layout.tsx`. No Context / Zustand / Redux.
+- **Slash commands:** UI-only data under `apps/web/model/slashCommands.ts`. Never sent to the API in any form (not even in `metadata`). Never promoted to `@portfolio/contracts`.
+- **Streaming:** out of scope. No `AsyncIterable` / `ReadableStream` / SSE in the client or the proxy.
+
+## Critical files / patterns to reuse (not reinvent)
+
+- **Contracts:** `packages/contracts/src/{chat,agent,errors,common}.ts` — re-exported from `packages/contracts/src/index.ts`. Use these directly.
+- **API endpoint being proxied:** `apps/api/src/routes/chat.ts`.
+- **Where the widget mounts:** `apps/web/app/layout.tsx`.
+- **Design tokens (already perfect match):** `apps/web/app/globals.css` — Tailwind v4 `@theme` with `--color-primary` (sky), `--color-secondary` (fuchsia), `--color-neutral`, custom utilities `neon-*`, `retro-button-*`, `bg-boxes-*`, animations `overlayShow` / `contentShow`. New animations `cwPop`, `cwSheet`, `cwBlink` will be added in Phase B.
+- **Dialog primitives:** `apps/web/components/common/Dialog/*` — Radix wrappers (Root, Trigger, Portal, Overlay, Content). `apps/web/components/common/Modal/Modal.tsx` shows the `onOpenAutoFocus={(e)=>e.preventDefault()}` pattern worth reusing.
+- **Existing primitives:** `apps/web/components/common/{Button,Card,Section,Typography,Slot,Highlight,Box}/` — reuse rather than reimplement. Note `Button` already supports `variant: 'primary' | 'secondary' | 'demoted'`.
+- **API hook convention:** `apps/web/hooks/api/useContact.ts` shows the folder convention. **Do not mirror its error handling** — it swallows errors via callbacks and never validates the response shape. The new agent client will validate with Zod and throw typed errors.
+- **Proxy route convention:** `apps/web/app/api/contact/route.ts` (currently a 501 stub) shows where the proxy file goes.
+- **Model folder:** `apps/web/model/ContactFormData.ts` — convention for typed data shapes. Both `slashCommands.ts` and `suggestedPrompts.ts` go here.
+- **Utils folder:** `apps/web/utils/{fonts,mergeProps}.ts` — convention for small utility modules. The plain `sendAgentMessage` function and `AgentClientError` class go here.
+- **Content source:** `packages/portfolio-content/src/contact.ts` currently exports `email`, `github`, `linkedin`, `twitter`, `resumePath`. Will additively gain `whatsappNumber: string` in Phase A.
+- **About page:** `apps/web/app/about/page.tsx:101` — where `projects` is rendered. Gets an `id="projects"` anchor in Phase A so `/projects` slash command can target `/about#projects`.
+- **Profile image:** `apps/web/public/profile.jpg` — exists, used by trigger pill and header avatar.
+
+Existing deps cover everything — **no installs needed**:
+
+- `@radix-ui/react-dialog` (panel + sheet primitive)
+- `framer-motion` (motion; already used by `components/common/Card`)
+- `react-feather` (icons)
+- `react-markdown` (assistant message rendering with inline `**bold**` and `/cmd` code spans)
+- `tailwind-merge` + `clsx` (class composition)
+- `zod` (transitively via `@portfolio/contracts`)
+
+---
+
+## Visual fidelity protocol (load-bearing for Phases B and C)
+
+The design contains ~900 lines of inline styles with exact pixel values, half-pixel font sizes (13.5px, 11.5px, 10.5px), multi-stop box-shadows, specific rgba gradients, and verbatim copy strings. Translating those to "the nearest Tailwind token" is where 1:1 fidelity dies. The default mode for Phase B and C is **literal port first, idiomize second** — never the other way around.
+
+### Rule 1 — Run the design prototype side-by-side with the dev build
+
+The design at `/tmp/design-extract/floating-ai-chat-card/project/index.html` is a self-contained React + Babel page; no build needed — just `open` it. Run `pnpm --filter web dev` in the other half of the screen. Every component built must be visually compared against the design before moving on. The design's `app.jsx` exposes seeded states (`<ChatWidget seed="welcome" />`, `seed="conversation"`, `seed="typing"`, `seed="slash"`, `seed="error"`, `seed="closed"`, `mobile`) so each Phase B / C deliverable has a pinned target to diff against.
+
+Phase B is not "done" until every seeded state in the design has a matching state in the real widget that visually agrees.
+
+### Rule 2 — Port styles literally first; refactor to Tailwind second
+
+For each component in Phase B, mirror the corresponding `cwStyles` entry from `chat-widget.jsx` verbatim. Two acceptable shapes:
+
+- **Tailwind arbitrary values** for one-off values: `w-[380px] h-[580px] text-[13.5px] tracking-[0.04em] rounded-[16px] shadow-[0_18px_40px_-18px_rgba(217,70,239,0.55)]`.
+- **A co-located `styles.ts`** exporting style objects with the same names as `cwStyles` (e.g. `triggerStyle`, `cardFrameStyle`, `headerStyle`), applied via the `style={}` prop where Tailwind arbitrary values would get unreadable.
+
+Do **not** pre-translate to nearest tokens during the initial port. `bg-fuchsia-700/20` is not a substitute for `rgba(217,70,239,0.18)` (the design's value resolves to ~`rgba(161,28,175,0.x)` — visibly different). After the side-by-side diff shows parity, idiomize *only* where token-equivalents are exact:
+
+- `var(--color-primary-500)` → `bg-primary-500` ✓ (exact)
+- `var(--color-secondary-700)` → `border-secondary-700` ✓ (exact)
+- `rgba(217,70,239,0.18)` → `bg-fuchsia-700/20` ✗ (approximate — keep the rgba)
+- `13.5px` → `text-sm` ✗ (drift from 14px) — keep `text-[13.5px]`
+- `cubic-bezier(0.16, 1, 0.3, 1)` → `ease-out` ✗ (different curve) — keep via `--ease-soft`
+
+### Rule 3 — Lift non-token values into CSS custom properties in `globals.css`
+
+Multi-stop shadows, gradient frames, and other magic values that appear more than once go into `globals.css` as `@theme` custom properties or `:root` variables, then get referenced via `shadow-[var(--cw-shadow-trigger)]` etc. Concretely, define at minimum:
+
+- `--cw-shadow-trigger` — the three-layer pill shadow.
+- `--cw-gradient-frame` — the 160deg sky→fuchsia hairline gradient used by both desktop card and mobile sheet.
+- `--cw-shadow-panel` — the desktop panel's drop+halo combo.
+- `--cw-dot-glow` — the typing dot box-shadow.
+
+This keeps the magic values in one auditable file rather than stringly-typed across a dozen components, and makes any future tweak a single edit.
+
+### Rule 4 — Verify with a forked agent at the end of Phase B and Phase C
+
+Same approach the design itself used (visible in `chats/chat1.md` as "fork_verifier_agent"). Spawn an `Explore` or general-purpose subagent with:
+
+- the design's `chat-widget.jsx` and corresponding seeded state in `app.jsx`,
+- the real implementation files, and
+- explicit instructions to spot visual diffs (dimensions, colors, shadows, animations, copy, layout).
+
+Cheap, parallelizable, and catches the drift the implementer's eye has normalized to.
+
+### Rule 5 — Copy strings are immutable
+
+All user-visible text in the design is final and load-bearing for tone. Extract verbatim into a co-located `strings.ts` (or read inline from this list), do not paraphrase:
+
+- Trigger label: `Ask David` (Silkscreen, uppercase via CSS).
+- Trigger sub-labels: `David Agent · online` (desktop), `tap to chat` (mobile).
+- Trigger aria-label: `Open David Agent — Ask David anything about David Bautista`.
+- Header name: `David Agent` (Silkscreen).
+- Header badge: `BETA`.
+- Header sub-text: `Ask about my projects, stack, experience, or leadership.`
+- Header WhatsApp aria-label (empty): `Start this conversation on WhatsApp`.
+- Header WhatsApp aria-label (active): `Continue this conversation on WhatsApp`.
+- Header close aria-label: `Close chat`.
+- Empty-state title: `— Hi, I'm David's agent —` (em-dashes, fuchsia-400).
+- Empty-state body: `I've read every line of his portfolio. Ask me about his stack, projects, or leadership — or fire off a slash command.`
+- Suggested-prompts divider: `try one of these`.
+- Slash popover header: `Skills · pick one to run a command`.
+- Composer placeholder: `Ask David anything…  (try / for skills)` (two spaces before the parenthetical).
+- Composer footer left: `Enter to send · Shift+Enter for newline`.
+- Composer footer right: `agent online` (with a green dot before it).
+- Typing caption: `thinking…`.
+- Error title: `The agent took a coffee break.`
+- Error body: `Couldn't reach David's brain just now — that's on me, not you. Try again, or just email david@davidbautista.co.` — pull the email from `@portfolio/content`.
+- Error retry button: `Retry`.
+- WhatsApp line left: `Prefer WhatsApp?` (with the WhatsApp glyph before it).
+- WhatsApp line right (empty): `Continue there →`.
+- WhatsApp line right (active): `Continue this chat there →`.
+
+These are the brand voice — first person, em-dashes, dry self-aware tone. Don't generate variants.
+
+---
+
+## Phase A — Plumbing & data (no UI changes)
+
+**Goal:** Working `/api/chat` proxy exercisable via `curl`, slash command + suggested prompt registries compiled, `/about#projects` anchor in place, `whatsappNumber` added to `@portfolio/content`, and `docs/05` updated to reflect the planning decisions. No React widget yet.
+
+**Files to create:**
+
+1. **`apps/web/app/api/chat/route.ts`** — dumb proxy. Reads `process.env.AGENT_API_URL`. Forwards `POST` body to `${AGENT_API_URL}/chat`. Returns the upstream JSON status + body unchanged. No auth, no transformation, no business logic. If `AGENT_API_URL` is unset, returns 500 with a clear server log (do not silently 200). JSON only; do not introduce SSE / `text/event-stream`.
+
+2. **`apps/web/utils/agentClient.ts`** — exports `sendAgentMessage(input: ChatRequest): Promise<ChatResponse>` and `AgentClientError` class. Internals:
+   - `fetch('/api/chat', { method: 'POST', body: JSON.stringify(input), headers: { 'content-type': 'application/json' } })`.
+   - On 2xx: `ChatResponseSchema.parse(await res.json())`, return.
+   - On non-2xx: `ErrorResponseSchema.parse(await res.json())`, throw `new AgentClientError({ code, message, details? })`.
+   - On network failure / JSON parse failure / schema mismatch: throw `new AgentClientError({ code: 'internal_error', message })` with the original wrapped via `Error.cause`.
+   - This is the single seam for all chat network access — UI components never call `fetch` directly.
+
+3. **`apps/web/model/slashCommands.ts`** — discriminated union and array:
+
+   ```ts
+   export type SlashCommand =
+     | { command: string; label: string; description: string; kind: 'prompt';   prompt: string }
+     | { command: string; label: string; description: string; kind: 'navigate'; href: string }
+     | { command: string; label: string; description: string; kind: 'external'; href: string };
+
+   import { contact } from '@portfolio/content';
+
+   export const slashCommands: readonly SlashCommand[] = [
+     { command: '/projects',   label: 'Projects',   description: "Browse what I'm proud of",          kind: 'navigate', href: '/about#projects' },
+     { command: '/stack',      label: 'Stack',      description: 'My tech stack & tools',             kind: 'prompt',   prompt: "What is David's technical stack?" },
+     { command: '/leadership', label: 'Leadership', description: '3+ years leading Front-End teams',  kind: 'prompt',   prompt: "Tell me about David's leadership experience." },
+     { command: '/contact',    label: 'Contact',    description: 'Email, LinkedIn, GitHub',           kind: 'navigate', href: '/contact' },
+     { command: '/whatsapp',   label: 'WhatsApp',   description: 'Continue this chat on WhatsApp',    kind: 'external', href: `https://wa.me/${contact.whatsappNumber}` },
+   ];
+   ```
+
+   `/twilio` is **not** in this list. `command` is unique (no separate `id`). The fields match the design's `cmd`/`hint` but with clearer naming.
+
+4. **`apps/web/model/suggestedPrompts.ts`** — separate list, referenced by the empty-state chips:
+
+   ```ts
+   export interface SuggestedPrompt {
+     label: string;
+     commandRef?: string; // matches a slashCommands[].command
+   }
+
+   export const suggestedPrompts: readonly SuggestedPrompt[] = [
+     { label: "What's David's technical stack?", commandRef: '/stack' },
+     { label: "Show me David's projects",        commandRef: '/projects' },
+     { label: 'What kind of engineer is David?', commandRef: undefined }, // sent as plain text
+     { label: 'Tell me about his leadership',    commandRef: '/leadership' },
+     { label: 'How can I contact David?',        commandRef: '/contact' },
+     { label: 'Why Twilio?',                     commandRef: undefined }, // /twilio is dropped; sent as plain text
+   ];
+   ```
+
+**Files to modify:**
+
+5. **`packages/portfolio-content/src/contact.ts`** — additively add `whatsappNumber: string` (E.164, user-provided at implementation time). Re-exported through `packages/portfolio-content/src/index.ts` (the existing barrel). Do not restructure other exports.
+
+6. **`apps/web/app/about/page.tsx`** — add `id="projects"` to the section/wrapper around line 101 where `projects.map(...)` is rendered. Smallest possible edit; do not restyle.
+
+7. **`apps/web/.env.local.example`** — add `AGENT_API_URL=http://127.0.0.1:3001` with a comment: `# URL where apps/api is reachable; consumed only by the /api/chat proxy route (server-side; do NOT prefix with NEXT_PUBLIC_).`
+
+8. **`docs/05-connect-web-chat-ui.prompt.md`** — update to reflect the decisions locked during planning:
+   - "Initial set" of slash commands: 5 entries as above; remove the WhatsApp-as-slash-replaces-Twilio framing.
+   - Add a "WhatsApp has three converging surfaces" subsection under Primary behavior (header button + persistent line + slash command, all pointing at the same `wa.me` href in `@portfolio/content`).
+   - Replace the "no parallel hardcoded lists" acceptance criterion with a more permissive one: "The empty-state suggested-prompt chips render from a `suggestedPrompts` list which may reference slash commands by `commandRef` but is not required to be 1:1 with the slash registry."
+   - Add a "Global `/` keyboard shortcut" item to Primary behavior.
+   - Note that Silkscreen *is* used inside the widget (trigger label + header name).
+   - Drop the "`SlashCommand` has `id` field" and "tag" guidance to match the simpler shape above.
+
+**Verification (no browser yet):**
+
+- `pnpm --filter @portfolio/content build` — confirms `whatsappNumber` export compiles.
+- `pnpm --filter @portfolio/api dev` in one terminal (Fastify on `:3001`).
+- `pnpm --filter web dev` in another terminal (Next on `:3000`).
+- `curl -sS -X POST http://localhost:3000/api/chat -H 'content-type: application/json' -d '{"message":"hi","channel":"web"}' | jq` → 200 with `ChatResponse` shape.
+- `curl -sS -X POST http://localhost:3000/api/chat -H 'content-type: application/json' -d '{"message":"hi","channel":"web","conversationId":"does-not-exist"}'` → 404 with `code: 'conversation_not_found'`.
+- `curl -sS -X POST http://localhost:3000/api/chat -H 'content-type: application/json' -d '{}'` → 400 with `code: 'validation_error'`.
+- Browser: visit `http://localhost:3000/about#projects` directly — projects section scrolls into view.
+- `pnpm lint` + `pnpm check-types` at repo root — clean.
+
+**Done when:** the proxy works, the client function validates both envelopes, both registries compile, `/about#projects` anchors correctly, `@portfolio/content` exposes the WhatsApp number, and `docs/05` reflects the planning decisions.
+
+---
+
+## Phase B — Desktop widget UI mounted globally
+
+**Goal:** Floating widget visible on every page on desktop. User can open it via the trigger pill or by pressing `/`, send messages, see suggested-prompt chips, use slash commands, handle errors, and reach WhatsApp through any of the three converging surfaces. Mobile works (no horizontal scroll, basic responsiveness) but isn't polished — Phase C.
+
+**Files to create — all under `apps/web/components/agent/DavidAgentWidget/`:**
+
+1. **`index.tsx`** — root widget. Marked `"use client"`. Owns:
+   - `open` state (boolean, default false)
+   - `messages` array of `ChatMessage`
+   - `conversationId` (string | undefined)
+   - `status` (`'idle' | 'sending' | 'error'`)
+   - `lastError` (`AgentClientError | undefined`)
+   - The `send(text: string)` function and `dispatch(command: SlashCommand)` function (both close over the above state)
+   - The global `/` keyboard listener via `useGlobalSlashShortcut`
+   - Renders `<ChatLauncher />` when collapsed, `<ChatPanel />` when open.
+
+2. **`ChatLauncher.tsx`** — the "Ask David" pill trigger. Per the design:
+   - Rounded-full pill, fuchsia border with retro `border-bottom: 4px`, glassy `rgba(10,10,10,0.78)` background with `backdrop-blur`, subtle fuchsia halo via box-shadow.
+   - Contents: profile avatar (32×32, rounded-full, fuchsia border) with a green pulse dot, label "ASK DAVID" in Silkscreen (uppercase, letter-spacing 0.04em), sub-label "David Agent · online" (or "tap to chat" on mobile), and a `/` kbd badge at the right.
+   - Hover: lifts `-2px`, brighter border.
+   - `aria-label="Open David Agent — Ask David anything about David Bautista"`.
+   - Mounts as the Radix `Dialog.Trigger` so Radix handles focus restoration on close.
+
+3. **`ChatPanel.tsx`** — the expanded panel. Wraps Radix `Dialog.Portal` / `Dialog.Content`. Desktop: 380×580, `fixed bottom-6 right-6`, 1px sky→fuchsia gradient hairline frame (`background: linear-gradient(160deg, rgba(14,165,233,0.55), rgba(217,70,239,0.6))` on a 1px-padded outer container, inner is the dark surface). Animation: `cwPop` (defined in `globals.css`) over 320ms with `var(--ease-soft)`. Composes header / scroll region / WhatsApp line / composer in flex column. **Mobile responsive behavior is best-effort in Phase B**, polish in Phase C.
+
+4. **`ChatHeader.tsx`** — left side: avatar (34×34, rounded-8) with green status dot, "DAVID AGENT" in Silkscreen, `BETA` pill (fuchsia tinted), sub-text "Ask about my projects, stack, experience, or leadership." Right side: WhatsApp icon button (uses `WhatsAppGlyph`, opens `wa.me` href in new tab, `aria-label` adapts to whether messages exist), close X button (`aria-label="Close chat"`).
+
+5. **`ChatMessageList.tsx`** — vertical scroll region. Auto-scrolls to bottom on new message, sending state change, or error state change (use `useLayoutEffect` checking `scrollHeight`). Renders the empty/welcome state when `messages.length === 0 && !sending && !error`, otherwise renders the thread. `aria-live="polite"` semantics are Phase C; Phase B leaves it as plain markup.
+
+6. **`ChatMessageBubble.tsx`** — single bubble component, props `{ role: 'user' | 'assistant'; text: string; first?: boolean }`. User: primary-500 background, white text, retro `border-bottom: 3px primary-600`, max-width 88%, smaller bottom-right radius for the tail. Assistant: `bg-surface-2` (neutral-900), neutral-700 border, fg-2 text (neutral-300), smaller bottom-left radius. Assistant text rendered via `react-markdown` so `**bold**` and `` `code` `` render correctly; tighten the schema by passing a restrictive component map (no images, no headings, no lists — keep it inline). Assistant rows include the avatar on the *first* row of an assistant run only (use the `first` prop, computed by the parent based on the previous message's role).
+
+7. **`TypingBubble.tsx`** — three fuchsia-400 dots with `cwBlink` animation (1.1s, delays 0/140/280ms) + "thinking…" caption. Same row layout as an assistant bubble (with avatar).
+
+8. **`ErrorBubble.tsx`** — assistant-row variant with a red-tinted avatar (alert icon), title "The agent took a coffee break.", body "Couldn't reach David's brain just now — that's on me, not you. Try again, or just email david@davidbautista.co.", and a Retry button. Pulls the email from `@portfolio/content` rather than hardcoding.
+
+9. **`ChatComposer.tsx`** — input row with: `/` icon button (left, toggles slash popover), text input (`placeholder="Ask David anything…  (try / for skills)"`), send button (right, primary-500 with retro border-bottom-3, arrow-up icon). Below the row: a footer line "Enter to send · Shift+Enter for newline" + green dot + "agent online". Send button is disabled when input is empty or `status === 'sending'`. Pressing Enter without Shift submits; Escape closes the slash popover. Phase B does single-line input behavior; full multiline + Shift+Enter newline is Phase C.
+
+10. **`SuggestedPrompts.tsx`** — empty/welcome state. Renders the title `— Hi, I'm David's agent —` (em-dashes in fuchsia-400), the body "I've read every line of his portfolio. Ask me about his stack, projects, or leadership — or fire off a slash command.", a divider with "try one of these", and the 6 chips from `suggestedPrompts`. Each chip: if `commandRef` resolves to a slash command, click dispatches that command (via the same `dispatch()` function the slash popover uses); otherwise click sends the `label` as plain text. Chips with a `commandRef` show the `command` text in a small code pill on the right.
+
+11. **`CommandSuggestions.tsx`** — slash popover anchored above the composer (`bottom: calc(100% - 4px)`). Header label "Skills · pick one to run a command". Rows are a grid `[command code] [description] [kind tag]` (the `kind` itself is fine as the right-side tag — `prompt | navigate | external`). Hover: fuchsia-tinted background. Reads from `slashCommands`. Filters by substring match on `command` and `label` when the composer has text starting with `/`. Phase B does click-only; keyboard nav is Phase C.
+
+12. **`WhatsAppLine.tsx`** — the persistent line between scroll region and composer. Layout: `[wa glyph] Prefer WhatsApp?  Continue [this chat] there →`. Border-top neutral-800, subtle green gradient background tint. Copy adapts: "Continue there" when messages.length === 0 && !sending && !error, else "Continue this chat there". Click opens the `wa.me` href (pulled from `@portfolio/content`) in a new tab.
+
+13. **`WhatsAppGlyph.tsx`** — inline SVG of the WhatsApp glyph, exactly as in the design (`#25D366` fill). Props: `size`, `color` (default `#25D366`). `aria-hidden="true"`. The brand green is contained *only* to the glyph — surrounding chrome stays in the portfolio palette.
+
+14. **`dispatchSlashCommand.ts`** — pure function `dispatchSlashCommand(cmd: SlashCommand, ctx: { router, send, closePanel }): void`. Switches on `kind`:
+    - `'prompt'` → `ctx.send(cmd.prompt)` (sends immediately as a normal chat message).
+    - `'navigate'` → `ctx.router.push(cmd.href)`, then `ctx.closePanel()`.
+    - `'external'` → `window.open(cmd.href, '_blank', 'noopener,noreferrer')`. Leaves panel open.
+    Keeping `kind` branching out of components makes it trivially testable.
+
+15. **`types.ts`** — `ChatMessage = { id: string; role: 'user' | 'assistant'; text: string; status?: 'sending' | 'error'; createdAt: string }`. Don't spread `ChatResponse` into render props.
+
+16. **`useGlobalSlashShortcut.ts`** — hook that registers a `keydown` listener on `window`. When `event.key === '/'` and `document.activeElement?.tagName` is not in `['INPUT', 'TEXTAREA']`, calls `openWidget()` and `event.preventDefault()`. (Escape-to-close is handled by Radix Dialog out of the box.)
+
+**Files to modify:**
+
+17. **`apps/web/app/layout.tsx`** — import and render `<DavidAgentWidget />` inside `<body>`, after `{children}`. One line.
+
+18. **`apps/web/app/globals.css`** — add three keyframes:
+    - `@keyframes cwPop` — `{ from: { opacity: 0, transform: translateY(8px) scale(0.985) } to: { opacity: 1, transform: none } }`
+    - `@keyframes cwSheet` — `{ from: { transform: translateY(28px), opacity: 0.6 } to: { transform: none, opacity: 1 } }`
+    - `@keyframes cwBlink` — `{ 0%, 80%, 100%: { opacity: 0.25, transform: translateY(0) } 40%: { opacity: 1, transform: translateY(-2px) } }`
+    Plus the `--animate-cwPop`, `--animate-cwSheet`, `--animate-cwBlink` variables in `@theme` so they're consumable via `animate-cwPop` etc.
+
+**Implementation notes:**
+
+- **Send semantics:** `send(text)` immediately appends a user `ChatMessage` with `status: undefined`, sets the conversation `status` to `'sending'`, then calls `sendAgentMessage({ message: text, channel: 'web', conversationId })`. On resolve: append the assistant `ChatMessage`, store `conversationId` from the response, set `status: 'idle'`. On `AgentClientError`: if `code === 'conversation_not_found'`, drop `conversationId` and retry once automatically (the user's intent was to keep talking — silently recover). For other codes: set `status: 'error'`, store `lastError`, leave `conversationId` intact.
+- **Duplicate-send guard:** while `status === 'sending'`, the send handler returns early and the composer's button is disabled.
+- **Retry from error bubble:** find the last user message and re-send it via `send(lastUser.text)`. Don't auto-include retry context (the API doesn't care).
+- **Unknown slash commands:** if user types `/asdf` and hits Enter, it goes through `send('/asdf')` like any other text. No special handling, no UI message.
+- **`ChatResponse.sources` / `confidence` / `shouldEscalate` / `traceId`:** ignored by the UI in this phase. Out of scope per the prompt.
+- **The `/whatsapp` slash command and the dedicated affordances (header button + persistent line) all pull the same href.** Define it once at the top of `index.tsx` (or in a small helper): `` const waHref = `https://wa.me/${contact.whatsappNumber}`; ``. Don't duplicate the URL construction in three places.
+- **Markdown rendering:** restrict `react-markdown` to an inline subset (`p`, `strong`, `em`, `code`) — no headings, no lists, no images, no code blocks. The assistant's answers should read as conversational, not as docs.
+
+**Verification:**
+
+- Run `pnpm --filter @portfolio/api dev` and `pnpm --filter web dev`.
+- Visit `/`, `/about`, `/contact`, `/demos` — trigger pill visible at bottom-right on each.
+- Click pill → panel opens with `cwPop` animation. Welcome state shows the 6 chips and the persistent WhatsApp line is visible *below* the chips area.
+- Press `/` anywhere (with no input focused) → widget opens.
+- Type "What is David's stack?" + send → user bubble appears immediately, typing bubble shows with 3 dots + "thinking…", assistant bubble appears with markdown rendered (bold + inline code).
+- Send while a message is pending → blocked (button disabled, second click no-op).
+- Type `/`, see filtered slash popover with rows `[/cmd] [description] [kind]`. Click `/stack` → sends canned prompt, response renders. Click `/projects` → router pushes `/about#projects`, panel closes, projects section in view. Click `/contact` → router pushes `/contact`, panel closes. Click `/whatsapp` → new tab opens with `wa.me/<number>`, panel stays open.
+- Click each of the 6 suggested chips — the ones with `commandRef` dispatch via the slash path; the ones without (`What kind of engineer is David?`, `Why Twilio?`) send the label text as plain user input.
+- Click the WhatsApp icon in the header → new tab opens with `wa.me/<number>`. With no messages, `aria-label` reads "Start this conversation on WhatsApp"; after sending a message, it reads "Continue this conversation on WhatsApp".
+- Click the persistent "Prefer WhatsApp?" line → new tab opens. Line copy is "Continue there" before any messages, "Continue this chat there" after.
+- Stop `apps/api` mid-conversation → error bubble appears with the canned copy and Retry button. Click Retry → re-sends the last user message.
+- Force-trigger `conversation_not_found`: in browser devtools, set the widget's `conversationId` to `"bogus"`, send → auto-retry kicks in, new conversation starts cleanly, no error visible to the user.
+- `pnpm lint` + `pnpm check-types` clean.
+
+**Done when:** the widget works end-to-end on desktop against the real agent, all five slash commands dispatch correctly, suggested-prompt chips work both with and without `commandRef`, both WhatsApp affordances (plus the slash command) all open the correct deep link, the global `/` shortcut opens the widget, and error envelopes are handled per `code`. **Mobile may look rough; that's Phase C.**
+
+---
+
+## Phase C — Mobile + accessibility polish
+
+**Goal:** Comfortable mobile UX (90vh bottom sheet) and screen-reader / keyboard parity with desktop.
+
+**Files to modify (no new files):**
+
+1. **`ChatPanel.tsx`** — mobile variant:
+   - On `< sm` viewports, switch from `fixed bottom-6 right-6 w-[380px] h-[580px]` to a bottom-sheet: `fixed inset-x-0 bottom-0 w-full max-h-[90dvh] rounded-t-[22px]`. Use `dvh` (dynamic viewport height) so the iOS URL bar doesn't clip the composer.
+   - Add the `cwSheet` animation in place of `cwPop` for the mobile variant.
+   - Add a grip handle (36×4 rounded pill, neutral-700, centered, ~6px from top).
+   - Add a dark backdrop (`rgba(0,0,0,0.55)` with `backdrop-blur-sm`) behind the sheet — clicking the backdrop closes the panel.
+   - Switch `onOpenAutoFocus={(e) => { e.preventDefault(); composerRef.current?.focus(); }}` so focus lands in the composer, not on the first focusable child (pattern from `components/common/Modal/Modal.tsx`).
+
+2. **`ChatLauncher.tsx`** — ensure 44×44 minimum touch target on mobile (`min-h-12 min-w-12 sm:min-h-14 sm:min-w-14` or equivalent). The sub-label text content swaps from "David Agent · online" to "tap to chat" on mobile (use Tailwind responsive `before:` / `after:` or render two spans with `hidden sm:inline` / `sm:hidden`).
+
+3. **`ChatMessageList.tsx`** — a11y:
+   - `role="log"`, `aria-live="polite"`, `aria-relevant="additions"` so screen readers announce new assistant messages without interrupting the user.
+   - `aria-busy={status === 'sending'}` during pending sends.
+   - Visually-hidden status node: `<span className="sr-only" aria-live="polite">{status === 'sending' ? 'David Agent is thinking…' : ''}</span>` so the typing indicator is announced, not just shown.
+
+4. **`ChatComposer.tsx`** — keyboard + a11y:
+   - Swap `<input>` for `<textarea>` with auto-grow (min 1 row, max 4 rows). Enter (no Shift) submits; Shift+Enter inserts a newline.
+   - Send button gets `aria-label="Send message"`.
+   - Add visible focus rings on textarea and send button (Tailwind `focus-visible:` utilities matching ContactForm's pattern: secondary-500 inset shadow on textarea, secondary-400 outline on buttons).
+   - Slash icon button gets `aria-label="Open commands"`.
+
+5. **`CommandSuggestions.tsx`** — keyboard nav:
+   - `role="listbox"` on the popover container, `role="option"` on each row with `aria-selected={isHighlighted}`.
+   - `aria-activedescendant` on the composer textarea pointing at the highlighted row's id.
+   - Arrow Up / Down moves the highlight. Enter dispatches. Escape closes the popover (does *not* close the panel).
+   - On dispatch: focus returns to the composer.
+
+6. **`ChatHeader.tsx`** — verify icon-only buttons have `aria-label`s (close: "Close chat", WhatsApp: adapts as described in Phase B).
+
+7. **`WhatsAppLine.tsx`** — ensure it's a single button (not a div with a click handler) for keyboard accessibility, with a descriptive `aria-label` matching the visible copy.
+
+8. **`globals.css`** — no new keyframes, but verify `prefers-reduced-motion` is respected: wrap `cwPop`, `cwSheet`, `cwBlink` in `@media (prefers-reduced-motion: no-preference)`.
+
+**Verification:**
+
+- Browser devtools at 320px width: launcher reachable and doesn't cover critical nav; sheet opens to ~90dvh; composer stays above the iOS keyboard; no horizontal scroll anywhere on the page.
+- Browser devtools at 768px and 1280px: floating panel renders correctly and doesn't overlap the homepage hero awkwardly.
+- Tab from page load: focus reaches launcher → Enter opens panel → focus is in composer → Tab cycles composer → send button → close button → WhatsApp button → through messages (or skip via roving focus). Escape closes → focus restored to launcher.
+- VoiceOver (macOS) or NVDA: opening the panel announces the dialog label; new assistant messages announce; "David Agent is thinking…" announces during sending.
+- Type `/` in the composer, use ↑/↓ to navigate, Enter to dispatch, Escape to close — all without leaving the keyboard.
+- Send a message via Enter; insert a newline via Shift+Enter — confirms textarea behavior.
+- Toggle "reduce motion" in OS settings — entrance animations don't run.
+- All Phase B verification still passes.
+- `pnpm lint` + `pnpm check-types` clean.
+
+**Done when:** every widget interaction is reachable by keyboard and announced to screen readers; mobile sheet doesn't fight the iOS keyboard or address bar; no horizontal scroll at 320px; visible focus rings on all interactive elements; reduced-motion respected.
+
+---
+
+## Explicitly out of scope (do not build, even speculatively)
+
+- Streaming chat responses (no `AsyncIterable`, no `ReadableStream`, no SSE in client or proxy).
+- Persisted conversations beyond in-memory `conversationId`.
+- "Start new conversation" / chat-clear button.
+- Source display UI (`ChatResponse.sources` are received but not rendered).
+- Trace/debug metadata panels.
+- Twilio inbound bridge (the WhatsApp affordances are deep links only).
+- Skill metadata or shortcut-id on the API request — **never**, even for analytics.
+- Promoting `SlashCommand` or `SuggestedPrompt` into `@portfolio/contracts`.
+- Carrying conversation context through to WhatsApp (the design notes a future "handoff token" idea; out of scope).
+- Animating message-by-message text reveal (would only matter once the API streams).
+
+## Cross-phase quality bar
+
+- Strict TypeScript, no `any`. Use `@portfolio/contracts` types directly.
+- `twMerge` for all conditional class composition (existing repo convention).
+- No new dependencies — every UI need is met by `framer-motion`, `@radix-ui/react-dialog`, `react-feather`, `react-markdown`, `tailwind-merge`, `clsx`.
+- Comments: only where the *why* is non-obvious. Don't restate what the code does.
+- `pnpm lint` (max-warnings 0) and `pnpm check-types` clean at the end of every phase.
+
+## Design source of truth
+
+The extracted design lives at `/tmp/design-extract/floating-ai-chat-card/project/`. Working protocol is the **Visual fidelity protocol** section above; key files for reference:
+
+- `chat-widget.jsx` — full reference implementation. The `cwStyles` object at the bottom is the source of truth for every dimension, color, shadow, gradient, and animation — port literally per Rule 2.
+- `app.jsx` — the seeded artboards (`seed="welcome" | "conversation" | "typing" | "slash" | "error" | "closed"`, plus `mobile`). Each is a pinned side-by-side target for the corresponding state in the real widget.
+- `design-system/colors_and_type.css` — design tokens; values already match `apps/web/app/globals.css` for primary/secondary/neutral scales.
+- `chats/chat1.md` — the design conversation that locked the WhatsApp affordances and the persistent line behavior (useful context if a future ambiguity arises).
+
+If the design and this plan disagree on a *visual* detail, the design wins. If they disagree on an *architectural* detail (state, contracts, registry shape, slash-command kinds), this plan wins — those overrides are listed under "Decisions locked during planning."

--- a/packages/portfolio-content/src/contact.ts
+++ b/packages/portfolio-content/src/contact.ts
@@ -14,4 +14,6 @@ export const contact = {
     handle: 'djbautista10',
   },
   resumePath: '/davidbautista.pdf',
+  whatsappNumber:
+    process.env.NEXT_PUBLIC_PORTFOLIO_WHATSAPP_NUMBER ?? '+15551234567',
 } as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@portfolio/content':
         specifier: workspace:*
         version: link:../../packages/portfolio-content
+      '@portfolio/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
       '@radix-ui/react-dialog':
         specifier: ^1.1.1
         version: 1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)

--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,9 @@
     "CHAT_MODEL",
     "CHAT_TIMEOUT_MS",
     "CHAT_MAX_TOKENS",
-    "NODE_ENV"
+    "NODE_ENV",
+    "AGENT_API_URL",
+    "NEXT_PUBLIC_PORTFOLIO_WHATSAPP_NUMBER"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary

Phase A of [docs/06-connect-web-chat-ui.plan.md](docs/06-connect-web-chat-ui.plan.md) — plumbing and data only, no UI yet. The widget itself lands in Phases B and C.

- **Proxy route** `apps/web/app/api/chat/route.ts` — same-origin Next.js handler that forwards POST bodies to `${AGENT_API_URL}/chat`. Intentionally dumb: no auth, no transformation. 500 if env unset, 502 on upstream fetch failure.
- **Agent client** `apps/web/utils/agentClient.ts` — `sendAgentMessage(input)` + `AgentClientError`, validating success against `ChatResponseSchema` and non-2xx against `ErrorResponseSchema` from `@portfolio/contracts`. Single seam for all chat network access.
- **Registries** `apps/web/model/{slashCommands,suggestedPrompts}.ts` — UI-only data. `slashCommands` is the 5-entry discriminated union (`/projects`, `/stack`, `/leadership`, `/contact`, `/whatsapp`); `command` is the unique key. `suggestedPrompts` is a separate list referencing slash commands by `commandRef` where it makes sense.
- **Content + anchor** — `whatsappNumber` added to `@portfolio/content/contact` (sourced from `NEXT_PUBLIC_PORTFOLIO_WHATSAPP_NUMBER`, fake fallback `+15551234567`). `id="projects"` on the about-page "I'm proud of" section so `/projects` can target `/about#projects` (required forwarding `...rest` on `Section`, which previously dropped all attrs).
- **Docs** — committed the planning doc (`docs/06`) and refreshed `docs/05` with the locked decisions: 5-entry slash set, WhatsApp's three converging surfaces, separate suggested-prompts list, global `/` shortcut, Silkscreen used inside the widget, `SlashCommand` shape without `id`.
- **Env wiring** — added `AGENT_API_URL` and `NEXT_PUBLIC_PORTFOLIO_WHATSAPP_NUMBER` to `apps/web/.env.local.example` and `turbo.json` globalEnv. Added `@portfolio/contracts` to `apps/web` deps.

## Test plan

- [x] `pnpm check-types` clean across 6 packages
- [x] `pnpm lint` clean (max-warnings 0)
- [x] `POST /api/chat {"message":"hi","channel":"web"}` → 200 with valid `ChatResponse`
- [x] `POST /api/chat {…,"conversationId":"does-not-exist"}` → 404 with `code: 'conversation_not_found'`
- [x] `POST /api/chat {}` → 400 with `code: 'validation_error'`
- [x] `GET /about` renders `id="projects"` on the projects section