### PR TITLE
Polish David Agent widget for mobile + a11y (Phase C)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -104,6 +104,20 @@
   --cw-dot-glow: 0 0 6px rgba(217, 70, 239, 0.5);
 }
 
+/* Shared focus-visible ring for widget interactive elements.
+   Outline (not box-shadow) so it stacks with the existing trigger/panel
+   shadows without clobbering them. */
+.cw-focus-ring:focus-visible {
+  outline: 2px solid var(--color-secondary-400);
+  outline-offset: 2px;
+}
+/* Inset variant for the composer textarea — outline-offset on the textarea
+   would push the ring outside the composer's rounded container. */
+.cw-focus-ring-inset:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--color-secondary-500);
+}
+
 @keyframes overlayShow {
   from {
     opacity: 0;

--- a/apps/web/components/agent/DavidAgentWidget/ChatComposer.tsx
+++ b/apps/web/components/agent/DavidAgentWidget/ChatComposer.tsx
@@ -52,12 +52,11 @@ export const ChatComposer = forwardRef<HTMLTextAreaElement, ChatComposerProps>(
     const filtered = useMemo(() => filterSlashCommands(filter), [filter]);
 
     // Keep the highlight in-range when the filtered list shrinks (e.g. user
-    // narrows from `/` to `/wha`).
+    // narrows from `/` to `/wha`). Functional setter so the effect only
+    // depends on the length, not the index it might overwrite.
     useEffect(() => {
-      if (highlightedIndex >= filtered.length) {
-        setHighlightedIndex(0);
-      }
-    }, [filtered.length, highlightedIndex]);
+      setHighlightedIndex((i) => (i >= filtered.length ? 0 : i));
+    }, [filtered.length]);
 
     // Auto-grow textarea between 1 and MAX_ROWS rows.
     useLayoutEffect(() => {

--- a/apps/web/components/agent/DavidAgentWidget/ChatComposer.tsx
+++ b/apps/web/components/agent/DavidAgentWidget/ChatComposer.tsx
@@ -1,6 +1,11 @@
 'use client';
 
 import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   type KeyboardEvent,
@@ -9,7 +14,11 @@ import { ArrowUp, Slash } from 'react-feather';
 
 import type { SlashCommand } from '@/model/slashCommands';
 
-import { CommandSuggestions } from './CommandSuggestions';
+import {
+  CommandSuggestions,
+  filterSlashCommands,
+  optionIdFor,
+} from './CommandSuggestions';
 
 interface ChatComposerProps {
   disabled: boolean;
@@ -17,171 +26,260 @@ interface ChatComposerProps {
   onSelectCommand: (command: SlashCommand) => void;
 }
 
-export function ChatComposer({
-  disabled,
-  onSendText,
-  onSelectCommand,
-}: ChatComposerProps) {
-  const [draft, setDraft] = useState('');
-  const [slashOpen, setSlashOpen] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
+const MAX_ROWS = 4;
+const OPTION_ID_PREFIX = 'cw-cmd';
 
-  const trimmed = draft.trim();
-  const canSubmit = trimmed.length > 0 && !disabled;
+export const ChatComposer = forwardRef<HTMLTextAreaElement, ChatComposerProps>(
+  function ChatComposer(
+    { disabled, onSendText, onSelectCommand }: ChatComposerProps,
+    externalRef,
+  ) {
+    const [draft, setDraft] = useState('');
+    const [slashOpen, setSlashOpen] = useState(false);
+    const [highlightedIndex, setHighlightedIndex] = useState(0);
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const submit = () => {
-    if (!canSubmit) return;
-    onSendText(trimmed);
-    setDraft('');
-    setSlashOpen(false);
-  };
+    useImperativeHandle(
+      externalRef,
+      () => textareaRef.current as HTMLTextAreaElement,
+      [],
+    );
 
-  const selectCommand = (command: SlashCommand) => {
-    setDraft('');
-    setSlashOpen(false);
-    onSelectCommand(command);
-    inputRef.current?.focus();
-  };
+    const trimmed = draft.trim();
+    const canSubmit = trimmed.length > 0 && !disabled;
 
-  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      submit();
-    } else if (e.key === 'Escape' && slashOpen) {
+    const filter = draft.startsWith('/') ? draft : '';
+    const filtered = useMemo(() => filterSlashCommands(filter), [filter]);
+
+    // Keep the highlight in-range when the filtered list shrinks (e.g. user
+    // narrows from `/` to `/wha`).
+    useEffect(() => {
+      if (highlightedIndex >= filtered.length) {
+        setHighlightedIndex(0);
+      }
+    }, [filtered.length, highlightedIndex]);
+
+    // Auto-grow textarea between 1 and MAX_ROWS rows.
+    useLayoutEffect(() => {
+      const el = textareaRef.current;
+      if (!el) return;
+      el.style.height = 'auto';
+      const styles = getComputedStyle(el);
+      const lineHeight = parseFloat(styles.lineHeight) || 20;
+      const paddingY =
+        parseFloat(styles.paddingTop) + parseFloat(styles.paddingBottom);
+      const max = lineHeight * MAX_ROWS + paddingY;
+      const next = Math.min(el.scrollHeight, max);
+      el.style.height = next + 'px';
+      el.style.overflowY = el.scrollHeight > max ? 'auto' : 'hidden';
+    }, [draft]);
+
+    const submit = () => {
+      if (!canSubmit) return;
+      onSendText(trimmed);
+      setDraft('');
       setSlashOpen(false);
-    }
-  };
+    };
 
-  return (
-    <div
-      style={{
-        position: 'relative',
-        borderTop: '1px solid var(--border-subtle)',
-        padding: '10px 10px 10px',
-        background: 'rgba(255,255,255,0.015)',
-        flex: '0 0 auto',
-      }}
-    >
-      {slashOpen && (
-        <CommandSuggestions
-          filter={draft.startsWith('/') ? draft : ''}
-          onSelect={selectCommand}
-        />
-      )}
+    const selectCommand = (command: SlashCommand) => {
+      setDraft('');
+      setSlashOpen(false);
+      onSelectCommand(command);
+      textareaRef.current?.focus();
+    };
+
+    const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      // When the slash popover is open, arrow/enter/escape navigate the list
+      // rather than acting on the textarea. Shift+Enter still always inserts
+      // a newline (default textarea behavior) so it works both inside and
+      // outside the popover.
+      if (slashOpen && filtered.length > 0) {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          setHighlightedIndex((i) => (i + 1) % filtered.length);
+          return;
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          setHighlightedIndex(
+            (i) => (i - 1 + filtered.length) % filtered.length,
+          );
+          return;
+        }
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          const next = filtered[highlightedIndex] ?? filtered[0];
+          if (next) selectCommand(next);
+          return;
+        }
+        if (e.key === 'Escape') {
+          // Close the popover but not the dialog. Stop propagation so Radix
+          // Dialog's Escape handler does not also fire.
+          e.preventDefault();
+          e.stopPropagation();
+          setSlashOpen(false);
+          return;
+        }
+      }
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        submit();
+      }
+    };
+
+    const popoverVisible = slashOpen && filtered.length > 0;
+    const activeOptionId = popoverVisible
+      ? optionIdFor(OPTION_ID_PREFIX, highlightedIndex)
+      : undefined;
+
+    return (
       <div
         style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 6,
-          padding: '6px 6px 6px 8px',
-          background: 'var(--color-neutral-950)',
-          border: '1px solid var(--border-subtle)',
-          borderRadius: 10,
-          transition: 'border-color 150ms, box-shadow 150ms',
+          position: 'relative',
+          borderTop: '1px solid var(--border-subtle)',
+          padding: '10px 10px 10px',
+          background: 'rgba(255,255,255,0.015)',
+          flex: '0 0 auto',
         }}
       >
-        <button
-          type="button"
-          aria-label="Open commands"
-          onClick={() => {
-            setSlashOpen((v) => !v);
-            inputRef.current?.focus();
-          }}
+        {slashOpen && (
+          <CommandSuggestions
+            filtered={filtered}
+            highlightedIndex={highlightedIndex}
+            onHighlight={setHighlightedIndex}
+            onSelect={selectCommand}
+            optionIdPrefix={OPTION_ID_PREFIX}
+          />
+        )}
+        <div
           style={{
-            width: 28,
-            height: 28,
-            borderRadius: 6,
-            background: 'transparent',
-            border: '1px solid transparent',
-            color: slashOpen ? 'var(--color-secondary-400)' : 'var(--fg-3)',
-            cursor: 'pointer',
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            flex: '0 0 auto',
-            transition: 'all 150ms',
+            display: 'flex',
+            alignItems: 'flex-end',
+            gap: 6,
+            padding: '6px 6px 6px 8px',
+            background: 'var(--color-neutral-950)',
+            border: '1px solid var(--border-subtle)',
+            borderRadius: 10,
+            transition: 'border-color 150ms, box-shadow 150ms',
           }}
         >
-          <Slash size={15} strokeWidth={1.75} />
-        </button>
-        <input
-          ref={inputRef}
-          value={draft}
-          onChange={(e) => {
-            const v = e.target.value;
-            setDraft(v);
-            setSlashOpen(v.trimStart().startsWith('/'));
-          }}
-          onKeyDown={onKeyDown}
-          placeholder="Ask David anything…  (try / for skills)"
-          aria-label="Message"
-          disabled={disabled}
-          style={{
-            flex: 1,
-            minWidth: 0,
-            background: 'transparent',
-            border: 'none',
-            outline: 'none',
-            color: 'var(--fg-1)',
-            fontFamily: 'var(--font-body)',
-            fontSize: 13.5,
-            fontWeight: 300,
-            padding: '6px 4px',
-          }}
-        />
-        <button
-          type="button"
-          aria-label="Send message"
-          onClick={submit}
-          disabled={!canSubmit}
-          style={{
-            width: 32,
-            height: 32,
-            flex: '0 0 auto',
-            borderRadius: 8,
-            background: 'var(--color-primary-500)',
-            border: '1px solid var(--color-primary-700)',
-            borderBottomWidth: 3,
-            color: 'white',
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            transition: 'all 150ms',
-            opacity: !canSubmit ? 0.4 : 1,
-            cursor: !canSubmit ? 'not-allowed' : 'pointer',
-          }}
-        >
-          <ArrowUp size={16} strokeWidth={2} />
-        </button>
-      </div>
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          fontSize: 10,
-          letterSpacing: '0.04em',
-          color: 'var(--fg-4)',
-          padding: '8px 6px 2px',
-          textTransform: 'lowercase',
-        }}
-      >
-        <span>Enter to send · Shift+Enter for newline</span>
-        <span
-          style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
-        >
-          <span
+          <button
+            type="button"
+            aria-label="Open commands"
+            aria-expanded={slashOpen}
+            className="cw-focus-ring"
+            onClick={() => {
+              setSlashOpen((v) => !v);
+              textareaRef.current?.focus();
+            }}
             style={{
-              width: 6,
-              height: 6,
-              borderRadius: 99,
-              background: '#22c55e',
-              boxShadow: '0 0 6px #22c55e',
+              width: 28,
+              height: 28,
+              borderRadius: 6,
+              background: 'transparent',
+              border: '1px solid transparent',
+              color: slashOpen ? 'var(--color-secondary-400)' : 'var(--fg-3)',
+              cursor: 'pointer',
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flex: '0 0 auto',
+              transition: 'all 150ms',
+            }}
+          >
+            <Slash size={15} strokeWidth={1.75} />
+          </button>
+          <textarea
+            ref={textareaRef}
+            value={draft}
+            onChange={(e) => {
+              const v = e.target.value;
+              setDraft(v);
+              setSlashOpen(v.trimStart().startsWith('/'));
+            }}
+            onKeyDown={onKeyDown}
+            placeholder="Ask David anything…  (try / for skills)"
+            aria-label="Message David Agent"
+            aria-autocomplete={popoverVisible ? 'list' : undefined}
+            aria-controls={
+              popoverVisible ? `${OPTION_ID_PREFIX}-listbox` : undefined
+            }
+            aria-activedescendant={activeOptionId}
+            disabled={disabled}
+            rows={1}
+            className="cw-focus-ring-inset"
+            style={{
+              flex: 1,
+              minWidth: 0,
+              background: 'transparent',
+              border: 'none',
+              outline: 'none',
+              color: 'var(--fg-1)',
+              fontFamily: 'var(--font-body)',
+              fontSize: 13.5,
+              fontWeight: 300,
+              padding: '6px 4px',
+              resize: 'none',
+              lineHeight: '20px',
+              maxHeight: 20 * MAX_ROWS + 12,
+              overflowY: 'hidden',
             }}
           />
-          <span>agent online</span>
-        </span>
+          <button
+            type="button"
+            aria-label="Send message"
+            className="cw-focus-ring"
+            onClick={submit}
+            disabled={!canSubmit}
+            style={{
+              width: 32,
+              height: 32,
+              flex: '0 0 auto',
+              borderRadius: 8,
+              background: 'var(--color-primary-500)',
+              border: '1px solid var(--color-primary-700)',
+              borderBottomWidth: 3,
+              color: 'white',
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              transition: 'all 150ms',
+              opacity: !canSubmit ? 0.4 : 1,
+              cursor: !canSubmit ? 'not-allowed' : 'pointer',
+            }}
+          >
+            <ArrowUp size={16} strokeWidth={2} />
+          </button>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            fontSize: 10,
+            letterSpacing: '0.04em',
+            color: 'var(--fg-4)',
+            padding: '8px 6px 2px',
+            textTransform: 'lowercase',
+          }}
+        >
+          <span>Enter to send · Shift+Enter for newline</span>
+          <span
+            style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
+          >
+            <span
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: 99,
+                background: '#22c55e',
+                boxShadow: '0 0 6px #22c55e',
+              }}
+            />
+            <span>agent online</span>
+          </span>
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  },
+);

--- a/apps/web/components/agent/DavidAgentWidget/ChatHeader.tsx
+++ b/apps/web/components/agent/DavidAgentWidget/ChatHeader.tsx
@@ -156,6 +156,7 @@ export function ChatHeader({
               : 'Start this conversation on WhatsApp'
           }
           title="Continue on WhatsApp"
+          className="cw-focus-ring"
           style={iconButtonStyle}
         >
           <WhatsAppGlyph size={14} />
@@ -164,6 +165,7 @@ export function ChatHeader({
           type="button"
           aria-label="Close chat"
           onClick={onClose}
+          className="cw-focus-ring"
           style={iconButtonStyle}
         >
           <X size={16} strokeWidth={1.75} />

--- a/apps/web/components/agent/DavidAgentWidget/ChatLauncher.tsx
+++ b/apps/web/components/agent/DavidAgentWidget/ChatLauncher.tsx
@@ -5,16 +5,12 @@ import { forwardRef, useState, type CSSProperties } from 'react';
 
 import { silkscreen } from '@/utils/fonts';
 
-interface ChatLauncherProps {
-  mobile?: boolean;
-}
-
 // Literal port of cwStyles.trigger family from the design (chat-widget.jsx:113).
 // Always rendered via <DialogTrigger asChild>; the click handler arrives via
 // Radix's cloneElement (captured by `...rest`). Hover state lives here so the
 // pill animates correctly regardless of who owns the click.
-export const ChatLauncher = forwardRef<HTMLButtonElement, ChatLauncherProps>(
-  function ChatLauncher({ mobile = false, ...rest }, ref) {
+export const ChatLauncher = forwardRef<HTMLButtonElement>(
+  function ChatLauncher(rest, ref) {
     const [hover, setHover] = useState(false);
 
     const triggerStyle: CSSProperties = {
@@ -23,6 +19,11 @@ export const ChatLauncher = forwardRef<HTMLButtonElement, ChatLauncherProps>(
       alignItems: 'center',
       gap: 12,
       padding: '10px 16px 10px 12px',
+      // 44px is the iOS HIG minimum touch target. The pill is comfortably
+      // larger on both axes already, but the explicit min protects against
+      // future style edits accidentally shrinking it below that.
+      minHeight: 44,
+      minWidth: 44,
       borderRadius: 999,
       border: '1px solid var(--color-secondary-700)',
       borderBottomWidth: 4,
@@ -35,7 +36,8 @@ export const ChatLauncher = forwardRef<HTMLButtonElement, ChatLauncherProps>(
       color: 'var(--fg-1)',
       cursor: 'pointer',
       boxShadow: 'var(--cw-shadow-trigger)',
-      transition: 'transform 200ms var(--ease-soft), background 200ms, border-color 200ms',
+      transition:
+        'transform 200ms var(--ease-soft), background 200ms, border-color 200ms',
       transform: hover ? 'translateY(-2px)' : 'translateY(0)',
       fontFamily: 'var(--font-body)',
     };
@@ -47,6 +49,7 @@ export const ChatLauncher = forwardRef<HTMLButtonElement, ChatLauncherProps>(
         aria-label="Open David Agent — Ask David anything about David Bautista"
         onMouseEnter={() => setHover(true)}
         onMouseLeave={() => setHover(false)}
+        className="cw-focus-ring"
         style={triggerStyle}
         {...rest}
       >
@@ -119,7 +122,12 @@ export const ChatLauncher = forwardRef<HTMLButtonElement, ChatLauncherProps>(
           >
             Ask David
           </span>
+          {/* Sub-label adapts to viewport via Tailwind responsive utilities —
+              `hidden sm:inline` shows the desktop string, `sm:hidden` shows
+              the mobile string. Inline styles don't set `display`, so the
+              utility classes win. */}
           <span
+            className="hidden sm:inline"
             style={{
               fontSize: 10.5,
               color: 'var(--fg-3)',
@@ -128,7 +136,19 @@ export const ChatLauncher = forwardRef<HTMLButtonElement, ChatLauncherProps>(
               textTransform: 'lowercase',
             }}
           >
-            {mobile ? 'tap to chat' : 'David Agent · online'}
+            David Agent · online
+          </span>
+          <span
+            className="sm:hidden"
+            style={{
+              fontSize: 10.5,
+              color: 'var(--fg-3)',
+              fontWeight: 300,
+              letterSpacing: '0.04em',
+              textTransform: 'lowercase',
+            }}
+          >
+            tap to chat
           </span>
         </span>
         <span

--- a/apps/web/components/agent/DavidAgentWidget/ChatLauncher.tsx
+++ b/apps/web/components/agent/DavidAgentWidget/ChatLauncher.tsx
@@ -1,15 +1,25 @@
 'use client';
 
 import Image from 'next/image';
-import { forwardRef, useState, type CSSProperties } from 'react';
+import {
+  forwardRef,
+  useState,
+  type ComponentPropsWithoutRef,
+  type CSSProperties,
+} from 'react';
 
 import { silkscreen } from '@/utils/fonts';
 
+type ChatLauncherProps = ComponentPropsWithoutRef<'button'>;
+
 // Literal port of cwStyles.trigger family from the design (chat-widget.jsx:113).
-// Always rendered via <DialogTrigger asChild>; the click handler arrives via
-// Radix's cloneElement (captured by `...rest`). Hover state lives here so the
-// pill animates correctly regardless of who owns the click.
-export const ChatLauncher = forwardRef<HTMLButtonElement>(
+// Always rendered via <DialogTrigger asChild>; click handler + ARIA state
+// (aria-haspopup, aria-expanded, data-state, …) arrive via Radix's
+// cloneElement and flow through `...rest`. Typed as button props so callers
+// (including Radix's runtime injection) line up with the type system. Hover
+// state lives here so the pill animates correctly regardless of who owns
+// the click.
+export const ChatLauncher = forwardRef<HTMLButtonElement, ChatLauncherProps>(
   function ChatLauncher(rest, ref) {
     const [hover, setHover] = useState(false);
 

--- a/apps/web/components/agent/DavidAgentWidget/ChatMessageList.tsx
+++ b/apps/web/components/agent/DavidAgentWidget/ChatMessageList.tsx
@@ -46,46 +46,49 @@ export function ChatMessageList({
   const empty = messages.length === 0 && !sending && !error;
 
   return (
-    <div
-      ref={scrollRef}
-      role="log"
-      aria-live="polite"
-      aria-relevant="additions"
-      aria-busy={sending || undefined}
-      aria-label="Conversation with David Agent"
-      style={{
-        flex: '1 1 auto',
-        overflowY: 'auto',
-        overflowX: 'hidden',
-        padding: '18px 16px 16px',
-      }}
-    >
-      {/* The typing bubble is decorative for screen readers (the dots aren't
-          announced). This node carries the announcement so assistive tech
-          hears that David Agent is thinking, parallel to the visual state. */}
-      <span style={srOnlyStyle} aria-live="polite" role="status">
+    <>
+      {/* Status node lives as a sibling of the log, not inside it — WAI-ARIA
+          authoring practice is to avoid nesting live regions. The typing
+          bubble has no announceable text (it's three dots), so this span
+          carries the "thinking…" announcement in parallel to the visual. */}
+      <span style={srOnlyStyle} role="status">
         {sending ? 'David Agent is thinking…' : ''}
       </span>
-      {empty ? (
-        emptyState
-      ) : (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-          {messages.map((m, i) => {
-            const prev = messages[i - 1];
-            const firstOfRun = !prev || prev.role !== m.role;
-            return (
-              <ChatMessageBubble
-                key={m.id}
-                role={m.role}
-                text={m.text}
-                first={firstOfRun}
-              />
-            );
-          })}
-          {sending && <TypingBubble />}
-          {error && <ErrorBubble onRetry={onRetry} />}
-        </div>
-      )}
-    </div>
+      <div
+        ref={scrollRef}
+        role="log"
+        aria-live="polite"
+        aria-relevant="additions"
+        aria-busy={sending || undefined}
+        aria-label="Conversation with David Agent"
+        style={{
+          flex: '1 1 auto',
+          overflowY: 'auto',
+          overflowX: 'hidden',
+          padding: '18px 16px 16px',
+        }}
+      >
+        {empty ? (
+          emptyState
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {messages.map((m, i) => {
+              const prev = messages[i - 1];
+              const firstOfRun = !prev || prev.role !== m.role;
+              return (
+                <ChatMessageBubble
+                  key={m.id}
+                  role={m.role}
+                  text={m.text}
+                  first={firstOfRun}
+                />
+              );
+            })}
+            {sending && <TypingBubble />}
+            {error && <ErrorBubble onRetry={onRetry} />}
+          </div>
+        )}
+      </div>
+    </>
   );
 }

--- a/apps/web/components/agent/DavidAgentWidget/ChatMessageList.tsx
+++ b/apps/web/components/agent/DavidAgentWidget/ChatMessageList.tsx
@@ -15,6 +15,20 @@ interface ChatMessageListProps {
   emptyState: ReactNode;
 }
 
+// Inline visually-hidden style — avoids a Tailwind dependency on this one
+// span and keeps the component self-contained.
+const srOnlyStyle = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0,0,0,0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+} as const;
+
 export function ChatMessageList({
   messages,
   sending,
@@ -34,6 +48,11 @@ export function ChatMessageList({
   return (
     <div
       ref={scrollRef}
+      role="log"
+      aria-live="polite"
+      aria-relevant="additions"
+      aria-busy={sending || undefined}
+      aria-label="Conversation with David Agent"
       style={{
         flex: '1 1 auto',
         overflowY: 'auto',
@@ -41,6 +60,12 @@ export function ChatMessageList({
         padding: '18px 16px 16px',
       }}
     >
+      {/* The typing bubble is decorative for screen readers (the dots aren't
+          announced). This node carries the announcement so assistive tech
+          hears that David Agent is thinking, parallel to the visual state. */}
+      <span style={srOnlyStyle} aria-live="polite" role="status">
+        {sending ? 'David Agent is thinking…' : ''}
+      </span>
       {empty ? (
         emptyState
       ) : (

--- a/apps/web/components/agent/DavidAgentWidget/ChatPanel.tsx
+++ b/apps/web/components/agent/DavidAgentWidget/ChatPanel.tsx
@@ -1,7 +1,13 @@
 'use client';
 
-import { Content, Description, Title } from '@radix-ui/react-dialog';
+import {
+  Content,
+  Description,
+  Overlay,
+  Title,
+} from '@radix-ui/react-dialog';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
+import { useEffect, useRef, useState, type CSSProperties } from 'react';
 
 import type { SlashCommand } from '@/model/slashCommands';
 
@@ -23,6 +29,25 @@ interface ChatPanelProps {
   onClose: () => void;
 }
 
+// Sub-`sm` breakpoint matches Tailwind's default (`min-width: 640px`).
+// Lazy-initialized so the first paint after the dialog opens is already
+// correct — the Portal does not render until `open === true`, so there is no
+// SSR markup to mismatch.
+function useIsMobile(): boolean {
+  const query = '(max-width: 639px)';
+  const [isMobile, setIsMobile] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia(query).matches;
+  });
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+  return isMobile;
+}
+
 export function ChatPanel({
   messages,
   sending,
@@ -34,70 +59,142 @@ export function ChatPanel({
   onClose,
 }: ChatPanelProps) {
   const hasMessages = messages.length > 0 || sending || error;
+  const isMobile = useIsMobile();
+  const composerRef = useRef<HTMLTextAreaElement>(null);
+
+  const desktopFrameStyle: CSSProperties = {
+    position: 'fixed',
+    right: 24,
+    bottom: 24,
+    zIndex: 50,
+    width: 380,
+    height: 580,
+    borderRadius: 16,
+    padding: 1,
+    background: 'var(--cw-gradient-frame)',
+    boxShadow: 'var(--cw-shadow-panel)',
+    animation: 'var(--animate-cwPop)',
+    fontFamily: 'var(--font-body)',
+    color: 'var(--fg-1)',
+  };
+
+  // dvh (dynamic viewport height) keeps the composer above the iOS URL bar
+  // when it expands; vh would clip.
+  const mobileFrameStyle: CSSProperties = {
+    position: 'fixed',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 50,
+    width: '100%',
+    maxHeight: '90dvh',
+    borderTopLeftRadius: 22,
+    borderTopRightRadius: 22,
+    padding: 1,
+    background: 'var(--cw-gradient-frame)',
+    animation: 'var(--animate-cwSheet)',
+    fontFamily: 'var(--font-body)',
+    color: 'var(--fg-1)',
+  };
+
+  const desktopInnerStyle: CSSProperties = {
+    position: 'relative',
+    width: '100%',
+    height: '100%',
+    borderRadius: 15,
+    background: 'var(--cw-gradient-surface)',
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+  };
+
+  const mobileInnerStyle: CSSProperties = {
+    position: 'relative',
+    width: '100%',
+    height: '100%',
+    borderTopLeftRadius: 21,
+    borderTopRightRadius: 21,
+    background: 'var(--cw-gradient-surface)',
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+    minHeight: 540,
+  };
 
   return (
-    <Content
-      onOpenAutoFocus={(e) => e.preventDefault()}
-      // Force the panel out of the document flow into a bottom-right anchor
-      // instead of the Radix default centered modal.
-      style={{
-        position: 'fixed',
-        right: 24,
-        bottom: 24,
-        zIndex: 50,
-        width: 380,
-        height: 580,
-        borderRadius: 16,
-        padding: 1,
-        background: 'var(--cw-gradient-frame)',
-        boxShadow: 'var(--cw-shadow-panel)',
-        animation: 'var(--animate-cwPop)',
-        fontFamily: 'var(--font-body)',
-        color: 'var(--fg-1)',
-      }}
-    >
-      <VisuallyHidden>
-        <Title>David Agent</Title>
-        <Description>
-          Ask David about his projects, stack, experience, or leadership.
-        </Description>
-      </VisuallyHidden>
-      <div
-        style={{
-          position: 'relative',
-          width: '100%',
-          height: '100%',
-          borderRadius: 15,
-          background: 'var(--cw-gradient-surface)',
-          display: 'flex',
-          flexDirection: 'column',
-          overflow: 'hidden',
+    <>
+      {isMobile && (
+        <Overlay
+          style={{
+            position: 'fixed',
+            inset: 0,
+            zIndex: 49,
+            background: 'rgba(0,0,0,0.55)',
+            backdropFilter: 'blur(4px)',
+            WebkitBackdropFilter: 'blur(4px)',
+          }}
+        />
+      )}
+      <Content
+        onOpenAutoFocus={(e) => {
+          // Default Radix focus would land on the first focusable child
+          // (the WhatsApp icon in the header). For a chat widget the
+          // composer is the obvious primary action — match Modal.tsx's
+          // intent of overriding initial focus.
+          e.preventDefault();
+          composerRef.current?.focus();
         }}
+        style={isMobile ? mobileFrameStyle : desktopFrameStyle}
       >
-        <ChatHeader
-          hasMessages={hasMessages}
-          whatsappHref={whatsappHref}
-          onClose={onClose}
-        />
-        <ChatMessageList
-          messages={messages}
-          sending={sending}
-          error={error}
-          onRetry={onRetry}
-          emptyState={
-            <SuggestedPrompts
-              onSendText={onSendText}
-              onDispatchCommand={onSelectCommand}
+        <VisuallyHidden>
+          <Title>David Agent</Title>
+          <Description>
+            Ask David about his projects, stack, experience, or leadership.
+          </Description>
+        </VisuallyHidden>
+        <div style={isMobile ? mobileInnerStyle : desktopInnerStyle}>
+          {isMobile && (
+            <span
+              aria-hidden="true"
+              style={{
+                position: 'absolute',
+                top: 6,
+                left: '50%',
+                transform: 'translateX(-50%)',
+                width: 36,
+                height: 4,
+                borderRadius: 99,
+                background: 'var(--color-neutral-700)',
+                zIndex: 2,
+              }}
             />
-          }
-        />
-        <WhatsAppLine hasMessages={hasMessages} href={whatsappHref} />
-        <ChatComposer
-          disabled={sending}
-          onSendText={onSendText}
-          onSelectCommand={onSelectCommand}
-        />
-      </div>
-    </Content>
+          )}
+          <ChatHeader
+            hasMessages={hasMessages}
+            whatsappHref={whatsappHref}
+            onClose={onClose}
+          />
+          <ChatMessageList
+            messages={messages}
+            sending={sending}
+            error={error}
+            onRetry={onRetry}
+            emptyState={
+              <SuggestedPrompts
+                onSendText={onSendText}
+                onDispatchCommand={onSelectCommand}
+              />
+            }
+          />
+          <WhatsAppLine hasMessages={hasMessages} href={whatsappHref} />
+          <ChatComposer
+            ref={composerRef}
+            disabled={sending}
+            onSendText={onSendText}
+            onSelectCommand={onSelectCommand}
+          />
+        </div>
+      </Content>
+    </>
   );
 }

--- a/apps/web/components/agent/DavidAgentWidget/CommandSuggestions.tsx
+++ b/apps/web/components/agent/DavidAgentWidget/CommandSuggestions.tsx
@@ -8,9 +8,26 @@ import {
   type SlashCommand,
 } from '@/model/slashCommands';
 
+export function filterSlashCommands(filter: string): SlashCommand[] {
+  const needle = filter.trim().toLowerCase();
+  if (!needle) return [...slashCommands];
+  return slashCommands.filter(
+    (c) =>
+      c.command.toLowerCase().includes(needle) ||
+      c.label.toLowerCase().includes(needle),
+  );
+}
+
+export function optionIdFor(prefix: string, index: number): string {
+  return `${prefix}-option-${index}`;
+}
+
 interface CommandSuggestionsProps {
-  filter: string;
+  filtered: SlashCommand[];
+  highlightedIndex: number;
+  onHighlight: (index: number) => void;
   onSelect: (command: SlashCommand) => void;
+  optionIdPrefix: string;
 }
 
 const itemStyle: CSSProperties = {
@@ -31,24 +48,38 @@ const itemStyle: CSSProperties = {
   transition: 'all 120ms',
 };
 
-function CommandRow({
-  command,
-  onSelect,
-}: {
+interface CommandRowProps {
+  id: string;
   command: SlashCommand;
+  highlighted: boolean;
   onSelect: (c: SlashCommand) => void;
-}) {
+  onHover: () => void;
+}
+
+function CommandRow({
+  id,
+  command,
+  highlighted,
+  onSelect,
+  onHover,
+}: CommandRowProps) {
   const [hover, setHover] = useState(false);
+  const active = hover || highlighted;
   return (
-    <button
-      type="button"
+    <div
+      id={id}
+      role="option"
+      aria-selected={highlighted}
       onClick={() => onSelect(command)}
-      onMouseEnter={() => setHover(true)}
+      onMouseEnter={() => {
+        setHover(true);
+        onHover();
+      }}
       onMouseLeave={() => setHover(false)}
       style={{
         ...itemStyle,
-        background: hover ? 'rgba(217,70,239,0.08)' : 'transparent',
-        borderColor: hover ? 'var(--color-secondary-700)' : 'transparent',
+        background: active ? 'rgba(217,70,239,0.08)' : 'transparent',
+        borderColor: active ? 'var(--color-secondary-700)' : 'transparent',
       }}
     >
       <code
@@ -76,27 +107,22 @@ function CommandRow({
       >
         {command.kind}
       </span>
-    </button>
+    </div>
   );
 }
 
 export function CommandSuggestions({
-  filter,
+  filtered,
+  highlightedIndex,
+  onHighlight,
   onSelect,
+  optionIdPrefix,
 }: CommandSuggestionsProps) {
-  const needle = filter.trim().toLowerCase();
-  const filtered = needle
-    ? slashCommands.filter(
-        (c) =>
-          c.command.toLowerCase().includes(needle) ||
-          c.label.toLowerCase().includes(needle),
-      )
-    : slashCommands;
-
   if (filtered.length === 0) return null;
 
   return (
     <div
+      id={`${optionIdPrefix}-listbox`}
       role="listbox"
       aria-label="Slash commands"
       style={{
@@ -117,6 +143,7 @@ export function CommandSuggestions({
       }}
     >
       <div
+        aria-hidden="true"
         style={{
           display: 'flex',
           alignItems: 'center',
@@ -133,8 +160,15 @@ export function CommandSuggestions({
         <Slash size={12} strokeWidth={1.75} />
         <span>Skills · pick one to run a command</span>
       </div>
-      {filtered.map((c) => (
-        <CommandRow key={c.command} command={c} onSelect={onSelect} />
+      {filtered.map((c, i) => (
+        <CommandRow
+          key={c.command}
+          id={optionIdFor(optionIdPrefix, i)}
+          command={c}
+          highlighted={i === highlightedIndex}
+          onSelect={onSelect}
+          onHover={() => onHighlight(i)}
+        />
       ))}
     </div>
   );

--- a/apps/web/components/agent/DavidAgentWidget/WhatsAppLine.tsx
+++ b/apps/web/components/agent/DavidAgentWidget/WhatsAppLine.tsx
@@ -50,6 +50,7 @@ export function WhatsAppLine({ hasMessages, href }: WhatsAppLineProps) {
             ? 'Continue this conversation on WhatsApp'
             : 'Open a new WhatsApp conversation with David'
         }
+        className="cw-focus-ring"
         style={{
           display: 'inline-flex',
           alignItems: 'center',


### PR DESCRIPTION
## Summary
- **Mobile bottom sheet**: `ChatPanel` now branches on a `useIsMobile` hook (`max-width: 639px`) — under `sm` it pins to the bottom with `max-h: 90dvh`, a gradient hairline frame, a grip handle, `cwSheet` entrance animation, and a Radix `<Overlay>` backdrop. Desktop layout (380×580 floating card) is unchanged.
- **Accessibility polish**: `<input>` swapped for an auto-growing `<textarea>` (1–4 rows); full keyboard navigation in the slash popover (ArrowUp/Down/Enter, Escape with `stopPropagation` so the dialog doesn't also close); `role=log` + `aria-live=polite` + `aria-busy` on the message list with an sr-only "thinking…" status; `aria-activedescendant` / `aria-controls` wiring between composer and listbox; `cw-focus-ring` class on every interactive element.
- **Touch + reduced motion**: launcher hits the 44×44 iOS HIG minimum; sub-label swaps to "tap to chat" via `hidden sm:inline` / `sm:hidden`; keyframes stay wrapped in `prefers-reduced-motion: no-preference` (already in place from a prior pass, verified).

8 files modified, no new files. Per docs/06's "Files to modify" list verbatim.

## Test plan
- [ ] `pnpm lint` and `pnpm check-types` clean (verified locally across the monorepo)
- [ ] At 320 / 768 / 1280 px in browser devtools:
  - 320: bottom sheet opens to ~90dvh, grip + backdrop visible, no horizontal scroll
  - 768: floating panel at bottom-right, no overlap with hero
  - 1280: same desktop card, unchanged from Phase B
- [ ] Keyboard-only nav from page load: Tab to launcher → Enter opens panel → focus lands in composer → `/` opens popover → ArrowDown/Up cycles rows → Enter dispatches → Escape closes popover (panel stays open)
- [ ] `prefers-reduced-motion: reduce` (OS setting): launcher hover lift + `cwPop`/`cwSheet`/`cwBlink` entrance animations skipped
- [ ] VoiceOver / NVDA: dialog title + description announced on open; new assistant messages announced via `role=log`; "David Agent is thinking…" announced during `sending`
- [ ] Phase B regressions: all five slash commands dispatch correctly; suggested-prompt chips with and without `commandRef` work; all three WhatsApp surfaces open the same `wa.me` href; `conversation_not_found` silently recovers
- [ ] Forked verifier agent: mobile bottom-sheet parity vs the design's iOS frames + a11y coverage (zero DRIFT, zero recommended fixes)