### PR TITLE
Replace heuristic grader with LLM grader

### DIFF
--- a/packages/agent/src/deps.ts
+++ b/packages/agent/src/deps.ts
@@ -2,7 +2,7 @@ import { prisma, retrieveChunks } from "@portfolio/db";
 import type { PrismaClient } from "@portfolio/db";
 import type { RetrievedChunk } from "@portfolio/contracts/knowledge";
 
-import { createHeuristicGrader } from "#grader/heuristic";
+import { createLLMGrader } from "#grader/llm";
 import type { ContextGrader } from "#grader/types";
 import { getChatProvider } from "#llm/index";
 import type { ChatProvider } from "#llm/types";
@@ -22,10 +22,11 @@ export interface AgentDeps {
 }
 
 export function resolveDeps(overrides: Partial<AgentDeps> = {}): AgentDeps {
+  const chatProvider = overrides.chatProvider ?? getChatProvider();
   return {
     prisma: overrides.prisma ?? prisma,
-    chatProvider: overrides.chatProvider ?? getChatProvider(),
-    grader: overrides.grader ?? createHeuristicGrader(),
+    chatProvider,
+    grader: overrides.grader ?? createLLMGrader({ chatProvider }),
     retrieve:
       overrides.retrieve ??
       ((input) =>

--- a/packages/agent/src/grader/heuristic.ts
+++ b/packages/agent/src/grader/heuristic.ts
@@ -1,6 +1,4 @@
-import type { RetrievedChunk } from "@portfolio/contracts/knowledge";
-
-import type { ContextGrader, ContextVerdict } from "./types";
+import type { ContextGrader, ContextVerdict, GradeInput } from "./types";
 
 export interface HeuristicGraderOptions {
   scoreFloor?: number;
@@ -28,7 +26,7 @@ export function createHeuristicGrader(
     options.minAcceptedCount ?? DEFAULTS.minAcceptedCount;
 
   return {
-    grade(chunks: RetrievedChunk[]): ContextVerdict {
+    grade({ chunks }: GradeInput): ContextVerdict {
       if (chunks.length === 0) {
         return {
           label: "none",

--- a/packages/agent/src/grader/llm.ts
+++ b/packages/agent/src/grader/llm.ts
@@ -1,0 +1,131 @@
+import type { RetrievedChunk } from "@portfolio/contracts/knowledge";
+
+import type { ChatProvider } from "#llm/types";
+import {
+  GraderResponseSchema,
+  buildGraderPrompt,
+  type GraderResponse,
+} from "#prompts/grader";
+
+import type { ContextGrader, ContextVerdict, GradeInput } from "./types";
+
+export interface LLMGraderOptions {
+  chatProvider: ChatProvider;
+  temperature?: number;
+}
+
+export function createLLMGrader(options: LLMGraderOptions): ContextGrader {
+  const { chatProvider, temperature = 0 } = options;
+
+  return {
+    async grade({ query, chunks }: GradeInput): Promise<ContextVerdict> {
+      if (chunks.length === 0) {
+        return {
+          label: "none",
+          accepted: [],
+          reason: "no chunks retrieved",
+        };
+      }
+
+      let parsed: GraderResponse;
+      try {
+        const prompt = buildGraderPrompt({ query, chunks });
+        const chatResult = await chatProvider.chat({
+          temperature,
+          messages: [
+            { role: "system", content: prompt.system },
+            { role: "user", content: prompt.user },
+          ],
+        });
+
+        const json = extractJsonObject(chatResult.content);
+        if (!json) {
+          return softFail(chunks, "grader_error: no JSON object in response");
+        }
+
+        const result = GraderResponseSchema.safeParse(JSON.parse(json));
+        if (!result.success) {
+          return softFail(
+            chunks,
+            `grader_error: schema mismatch (${result.error.issues[0]?.message ?? "unknown"})`,
+          );
+        }
+        parsed = result.data;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return softFail(chunks, `grader_error: ${message}`);
+      }
+
+      if (parsed.label !== "good") {
+        const { topScore, meanScore } = scoreStats(chunks);
+        return {
+          label: parsed.label,
+          accepted: [],
+          reason: parsed.reason || undefined,
+          topScore,
+          meanScore,
+        };
+      }
+
+      const acceptedIds = new Set(parsed.acceptedChunkIds);
+      const accepted = chunks.filter((c) => acceptedIds.has(c.chunkId));
+
+      if (accepted.length === 0) {
+        const { topScore, meanScore } = scoreStats(chunks);
+        return {
+          label: "weak",
+          accepted: [],
+          reason: "good label but no chunks selected",
+          topScore,
+          meanScore,
+        };
+      }
+
+      const { topScore, meanScore } = scoreStats(accepted);
+      return {
+        label: "good",
+        accepted,
+        reason: parsed.reason || undefined,
+        topScore,
+        meanScore,
+      };
+    },
+  };
+}
+
+function scoreStats(chunks: RetrievedChunk[]): {
+  topScore?: number;
+  meanScore?: number;
+} {
+  if (chunks.length === 0) return {};
+  const topScore = chunks.reduce(
+    (acc, c) => (c.score > acc ? c.score : acc),
+    0,
+  );
+  const meanScore =
+    chunks.reduce((acc, c) => acc + c.score, 0) / chunks.length;
+  return { topScore, meanScore };
+}
+
+// Soft-fail to "weak" so the existing retry-then-fallback router handles
+// transient LLM problems gracefully — matches the rewriter's pattern of
+// degrading instead of crashing the graph.
+function softFail(chunks: RetrievedChunk[], reason: string): ContextVerdict {
+  const { topScore, meanScore } = scoreStats(chunks);
+  return {
+    label: "weak",
+    accepted: [],
+    reason,
+    topScore,
+    meanScore,
+  };
+}
+
+// Models occasionally wrap JSON in ```json fences or add a trailing sentence
+// even when told not to. Locate the outermost {...} and return that slice.
+function extractJsonObject(content: string): string | null {
+  const start = content.indexOf("{");
+  const end = content.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) return null;
+  return content.slice(start, end + 1);
+}

--- a/packages/agent/src/grader/types.ts
+++ b/packages/agent/src/grader/types.ts
@@ -2,6 +2,11 @@ import type { RetrievedChunk } from "@portfolio/contracts/knowledge";
 
 export type RelevanceLabel = "good" | "weak" | "none";
 
+export interface GradeInput {
+  query: string;
+  chunks: RetrievedChunk[];
+}
+
 export interface ContextVerdict {
   label: RelevanceLabel;
   accepted: RetrievedChunk[];
@@ -11,5 +16,5 @@ export interface ContextVerdict {
 }
 
 export interface ContextGrader {
-  grade(chunks: RetrievedChunk[]): ContextVerdict | Promise<ContextVerdict>;
+  grade(input: GradeInput): ContextVerdict | Promise<ContextVerdict>;
 }

--- a/packages/agent/src/graph/nodes/gradeContext.ts
+++ b/packages/agent/src/graph/nodes/gradeContext.ts
@@ -6,8 +6,13 @@ import { withStep } from "./step";
 export function makeGradeContext(deps: AgentDeps) {
   return async (state: GraphState): Promise<Partial<GraphState>> => {
     const { result, step } = await withStep("grade_context", async () => {
+      // Grade against the user's original question — the answer node also
+      // generates against originalQuery (see generateAnswer.ts), so the
+      // grader must judge whether the chunks support that, not whatever
+      // the rewriter happened to ask. The rewriter is told to preserve
+      // intent, but we don't want correctness to depend on its fidelity.
       const verdict = await deps.grader.grade({
-        query: state.currentQuery,
+        query: state.originalQuery,
         chunks: state.retrievedChunks,
       });
       const accepted = verdict.label === "good" ? verdict.accepted : [];

--- a/packages/agent/src/graph/nodes/gradeContext.ts
+++ b/packages/agent/src/graph/nodes/gradeContext.ts
@@ -6,7 +6,10 @@ import { withStep } from "./step";
 export function makeGradeContext(deps: AgentDeps) {
   return async (state: GraphState): Promise<Partial<GraphState>> => {
     const { result, step } = await withStep("grade_context", async () => {
-      const verdict = await deps.grader.grade(state.retrievedChunks);
+      const verdict = await deps.grader.grade({
+        query: state.currentQuery,
+        chunks: state.retrievedChunks,
+      });
       const accepted = verdict.label === "good" ? verdict.accepted : [];
       return {
         result: { verdict, accepted },

--- a/packages/agent/src/prompts/grader.ts
+++ b/packages/agent/src/prompts/grader.ts
@@ -1,0 +1,62 @@
+import type { RetrievedChunk } from "@portfolio/contracts/knowledge";
+import { z } from "zod";
+
+export interface GraderPromptInput {
+  query: string;
+  chunks: RetrievedChunk[];
+}
+
+export interface GraderPrompt {
+  system: string;
+  user: string;
+}
+
+const CHUNK_PREVIEW_CHARS = 600;
+
+const SYSTEM_PROMPT = [
+  "You judge whether retrieved knowledge chunks support answering a question about David Bautista's portfolio (his experience, projects, skills, and background).",
+  "Choose one label:",
+  '- "good": at least one chunk directly supports a confident, specific answer to the question.',
+  '- "weak": chunks are related to the topic but do not contain enough to answer confidently.',
+  '- "none": chunks are off-topic or do not address the question at all.',
+  'When the label is "good", list the chunkIds of the chunks that actually support the answer in acceptedChunkIds. Be conservative — exclude tangentially-related chunks even if they share keywords.',
+  'When the label is "weak" or "none", acceptedChunkIds must be an empty array.',
+  'Output JSON ONLY matching this exact shape — no prose, no code fences, no commentary:',
+  '{"label":"good"|"weak"|"none","reason":"<one short sentence>","acceptedChunkIds":["<chunkId>", ...]}',
+].join("\n");
+
+export function buildGraderPrompt(input: GraderPromptInput): GraderPrompt {
+  const lines: string[] = [`Question: ${input.query}`, "", "Retrieved chunks:"];
+
+  if (input.chunks.length === 0) {
+    lines.push("(none)");
+  } else {
+    for (const chunk of input.chunks) {
+      const title = chunk.title ?? "Untitled";
+      const preview = chunk.content
+        .slice(0, CHUNK_PREVIEW_CHARS)
+        .replace(/\s+/g, " ")
+        .trim();
+      lines.push(
+        `[${chunk.chunkId}] (${chunk.sourceType}, score=${chunk.score.toFixed(2)}) ${title}`,
+      );
+      lines.push(preview);
+      lines.push("");
+    }
+  }
+
+  lines.push("Return JSON only.");
+
+  return {
+    system: SYSTEM_PROMPT,
+    user: lines.join("\n"),
+  };
+}
+
+export const GraderResponseSchema = z.object({
+  label: z.enum(["good", "weak", "none"]),
+  reason: z.string().default(""),
+  acceptedChunkIds: z.array(z.string()).default([]),
+});
+
+export type GraderResponse = z.infer<typeof GraderResponseSchema>;


### PR DESCRIPTION
## Summary
- Replace `createHeuristicGrader` (raw cosine thresholds) with `createLLMGrader` as the default `ContextGrader` in `AgentDeps`. The heuristic was a Phase 2 placeholder — on the current corpus, on-topic recruiter queries scored ~0.42 raw / ~0.59 post-rewrite, well below the 0.78 threshold, so every question fell to `low + escalate` even when the right chunk was retrieved.
- New LLM grader semantically judges support, returns `good | weak | none`, and (when `good`) selects the specific `chunkIds` that back the answer. Soft-fails to `weak` on malformed JSON / network errors so the existing retry-then-fallback router handles transient hiccups instead of crashing the graph (mirrors `rewriteQuery.ts`'s graceful-degradation pattern).
- `ContextGrader.grade` now takes `{ query, chunks }` so the LLM has the question available. `gradeContext.ts` passes `state.originalQuery` (matching `generateAnswer.ts`, which also generates against `originalQuery`) so the grader judges chunks against the user's actual question, not a possibly-drifted rewrite. Heuristic grader stays exported as an opt-in offline fallback.

## Verification
Smoke (`pnpm -F @portfolio/agent smoke:agent`) — both cases pass:
- **Answerable** \"What is David's technical stack?\" → `confidence: high`, no rewrites needed. Previously fell to `low + escalate`. The LLM grader accepted chunks #1 (Primary stack, score 0.52) and #4 (Bio, score 0.41) — both well below the old heuristic threshold.
- **Unanswerable** \"What is David's favorite database indexing strategy?\" → `confidence: low`, `shouldEscalate: true`, one rewrite attempted, then fallback. No false positive.

Persisted `grade_context` metadata for the smoke traces has `label`, `reason`, `topScore`, `meanScore`, and `acceptedCount` populated (verified via psql against `AgentStep`).

## Test plan
- [x] `pnpm -F @portfolio/agent check-types`
- [x] `pnpm -F @portfolio/agent lint`
- [x] `pnpm -F @portfolio/agent smoke:agent` — answerable returns high, unanswerable returns low + escalate
- [x] Spot-check the `grade_context` step metadata in a persisted trace — `label`, `reason`, `topScore`, `meanScore`, `acceptedCount` all populated

## Out of scope
- Expanding the knowledge corpus (independent follow-up — recruiter answers still benefit from richer source documents).
- Unit tests for the grader. The package has no test runner; the grader's soft-fail branches (parse failure, schema mismatch, hallucinated chunkIds, empty selection, thrown `chatProvider.chat`) are verified by code-reading only. A fake-`ChatProvider` unit test would land this and is a natural follow-up.
- Persisting the LLM grader's raw response and rejected chunkIds in trace metadata for post-hoc tuning — also a natural follow-up.